### PR TITLE
APP-20: Allow users to change their password.

### DIFF
--- a/Sparky.TrakApp.Model/Settings/ChangePasswordRequest.cs
+++ b/Sparky.TrakApp.Model/Settings/ChangePasswordRequest.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Sparky.TrakApp.Model.Settings
+{
+    [ExcludeFromCodeCoverage]
+    public class ChangePasswordRequest
+    {
+        public string RecoveryToken { get; set; }
+        
+        public string Username { get; set; }
+
+        public string NewPassword { get; set; }
+    }
+}

--- a/Sparky.TrakApp.Model/Settings/Validation/ChangePasswordDetails.cs
+++ b/Sparky.TrakApp.Model/Settings/Validation/ChangePasswordDetails.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Sparky.TrakApp.Model.Settings.Validation
+{
+    [ExcludeFromCodeCoverage]
+    public class ChangePasswordDetails
+    {
+        public string RecoveryToken { get; set; }
+        
+        public string NewPassword { get; set; }
+        
+        public string ConfirmNewPassword { get; set; }
+    }
+}

--- a/Sparky.TrakApp.Service/IAuthService.cs
+++ b/Sparky.TrakApp.Service/IAuthService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Sparky.TrakApp.Model.Login;
 using Sparky.TrakApp.Model.Response;
+using Sparky.TrakApp.Model.Settings;
 
 namespace Sparky.TrakApp.Service
 {
@@ -17,5 +18,9 @@ namespace Sparky.TrakApp.Service
         Task<CheckedResponse<UserResponse>> RegisterAsync(RegistrationRequest registrationRequest);
 
         Task<CheckedResponse<UserResponse>> RecoverAsync(RecoveryRequest recoveryRequest);
+
+        Task RequestChangePasswordAsync(string username);
+
+        Task<CheckedResponse<bool>> ChangePasswordAsync(ChangePasswordRequest changePasswordRequest);
     }
 }

--- a/Sparky.TrakApp.Service/ServiceRegistry.cs
+++ b/Sparky.TrakApp.Service/ServiceRegistry.cs
@@ -45,7 +45,7 @@ namespace Sparky.TrakApp.Service
                 {
                     client.BaseAddress = new Uri(environmentUrl);
                 })
-                .AddPolicyHandler(timeoutPolicy)
+                .AddPolicyHandler(Policy.TimeoutAsync<HttpResponseMessage>(20))
                 .AddHttpMessageHandler(c => new AuthTokenHandler(storageService))
                 .AddHttpMessageHandler(c => new RefreshTokenHandler(storageService));
 

--- a/Sparky.TrakApp.ViewModel.Test/BaseMasterDetailViewModelTest.cs
+++ b/Sparky.TrakApp.ViewModel.Test/BaseMasterDetailViewModelTest.cs
@@ -61,6 +61,21 @@ namespace Sparky.TrakApp.ViewModel.Test
         }
 
         [Test]
+        public void LoadSettingsCommand_WithNoData_DoesntThrowException()
+        {
+            // Arrange
+            _navigationService.Setup(mock => mock.NavigateAsync("BaseNavigationPage/SettingsPage"))
+                .Verifiable();
+
+            // Act
+            _baseMasterDetailViewModel.LoadSettingsCommand.Execute().Subscribe();
+            _scheduler.Start();
+
+            // Assert
+            _navigationService.Verify();
+        }
+
+        [Test]
         public void LogoutCommand_ThrowsException_NavigatesToLoginPage()
         {
             // Arrange

--- a/Sparky.TrakApp.ViewModel.Test/Settings/ChangePasswordViewModelTest.cs
+++ b/Sparky.TrakApp.ViewModel.Test/Settings/ChangePasswordViewModelTest.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using Acr.UserDialogs;
+using Microsoft.Reactive.Testing;
+using Moq;
+using NUnit.Framework;
+using Prism.Navigation;
+using Sparky.TrakApp.Model.Response;
+using Sparky.TrakApp.Model.Settings;
+using Sparky.TrakApp.Service;
+using Sparky.TrakApp.Service.Exception;
+using Sparky.TrakApp.ViewModel.Resources;
+using Sparky.TrakApp.ViewModel.Settings;
+
+namespace Sparky.TrakApp.ViewModel.Test.Settings
+{
+    [TestFixture]
+    public class ChangePasswordViewModelTest
+    {
+        private Mock<INavigationService> _navigationService;
+        private Mock<IStorageService> _storageService;
+        private Mock<IRestService> _restService;
+        private Mock<IAuthService> _authService;
+        private Mock<IUserDialogs> _userDialogs;
+        private TestScheduler _scheduler;
+
+        private ChangePasswordViewModel _changePasswordViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _navigationService = new Mock<INavigationService>();
+            _storageService = new Mock<IStorageService>();
+            _restService = new Mock<IRestService>();
+            _authService = new Mock<IAuthService>();
+            _userDialogs = new Mock<IUserDialogs>();
+            _scheduler = new TestScheduler();
+
+            _changePasswordViewModel = new ChangePasswordViewModel(_scheduler, _navigationService.Object,
+                _storageService.Object, _restService.Object, _authService.Object, _userDialogs.Object);
+        }
+
+        [Test]
+        public void ClearValidationCommand_WithNoData_DoesntThrowException()
+        {
+            // Assert
+            Assert.DoesNotThrow(() =>
+            {
+                _changePasswordViewModel.ClearValidationCommand.Execute().Subscribe();
+                _scheduler.Start();
+            });
+        }
+
+        [Test]
+        public void ChangeCommand_WithInvalidData_DoesntSendChangePasswordRequest()
+        {
+            // Act
+            _changePasswordViewModel.ChangeCommand.Execute().Subscribe();
+            _scheduler.Start();
+
+            // Assert
+            _authService.Verify(a => a.RequestChangePasswordAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void ChangeCommand_ThrowsApiException_SetsErrorMessageAsApiError()
+        {
+            // Arrange
+            _changePasswordViewModel.ResetToken.Value = string.Concat(Enumerable.Repeat("a", 30));
+            _changePasswordViewModel.NewPassword.Value = "Password123";
+            _changePasswordViewModel.ConfirmNewPassword.Value = "Password123";
+
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            _authService.Setup(m => m.ChangePasswordAsync(It.IsAny<ChangePasswordRequest>()))
+                .Throws(new ApiException());
+
+            // Act
+            _changePasswordViewModel.ChangeCommand.Execute().Catch(Observable.Return(Unit.Default)).Subscribe();
+            _scheduler.Start();
+            
+            // Assert
+            Assert.IsTrue(_changePasswordViewModel.IsError,
+                "_changePasswordViewModel.IsError should be true if an exception is thrown.");
+            Assert.AreEqual(Messages.ErrorMessageApiError, _changePasswordViewModel.ErrorMessage,
+                "The error message is incorrect.");
+            
+            _navigationService.Verify(m => m.NavigateAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void ChangeCommand_ThrowsException_SetsErrorMessageAsApiGeneric()
+        {
+            // Arrange
+            _changePasswordViewModel.ResetToken.Value = string.Concat(Enumerable.Repeat("a", 30));
+            _changePasswordViewModel.NewPassword.Value = "Password123";
+            _changePasswordViewModel.ConfirmNewPassword.Value = "Password123";
+
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            _authService.Setup(m => m.ChangePasswordAsync(It.IsAny<ChangePasswordRequest>()))
+                .Throws(new Exception());
+
+            // Act
+            _changePasswordViewModel.ChangeCommand.Execute().Catch(Observable.Return(Unit.Default)).Subscribe();
+            _scheduler.Start();
+            
+            // Assert
+            Assert.IsTrue(_changePasswordViewModel.IsError,
+                "_changePasswordViewModel.IsError should be true if an exception is thrown.");
+            Assert.AreEqual(Messages.ErrorMessageGeneric, _changePasswordViewModel.ErrorMessage,
+                "The error message is incorrect.");
+            
+            _navigationService.Verify(m => m.NavigateAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void ChangeCommand_WithCheckedResponseError_SetsErrorMessage()
+        {
+            // Arrange
+            _changePasswordViewModel.ResetToken.Value = string.Concat(Enumerable.Repeat("a", 30));
+            _changePasswordViewModel.NewPassword.Value = "Password123";
+            _changePasswordViewModel.ConfirmNewPassword.Value = "Password123";
+
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            var response = new CheckedResponse<bool>
+            {
+                Error = true,
+                ErrorMessage = "error-message"
+            };
+            
+            _authService.Setup(m => m.ChangePasswordAsync(It.IsAny<ChangePasswordRequest>()))
+                .ReturnsAsync(response);
+            
+            // Act
+            _changePasswordViewModel.ChangeCommand.Execute();
+            _scheduler.Start();
+            
+            // Assert
+            Assert.IsTrue(_changePasswordViewModel.IsError,
+                "_changePasswordViewModel.IsError should be true if the response has an error.");
+            Assert.AreEqual(response.ErrorMessage, _changePasswordViewModel.ErrorMessage,
+                "The error message is incorrect.");
+            
+            _navigationService.Verify(m => m.NavigateAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void ChangeCommand_WithSuccessfulCheckedResponse_LogsOutAndNavigatesToLoginPage()
+        {
+            // Arrange
+            _changePasswordViewModel.ResetToken.Value = string.Concat(Enumerable.Repeat("a", 30));
+            _changePasswordViewModel.NewPassword.Value = "Password123";
+            _changePasswordViewModel.ConfirmNewPassword.Value = "Password123";
+
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+            
+            _authService.Setup(m => m.ChangePasswordAsync(It.IsAny<ChangePasswordRequest>()))
+                .ReturnsAsync(new CheckedResponse<bool>
+                {
+                    Error = false
+                });
+
+            _storageService.Setup(m => m.GetUserIdAsync())
+                .ReturnsAsync(0L);
+
+            _storageService.Setup(m => m.GetDeviceIdAsync())
+                .ReturnsAsync(Guid.Empty);
+            
+            _restService.Setup(m => m.DeleteAsync(It.IsAny<string>()))
+                .Verifiable();
+
+            _storageService.Setup(m => m.SetUsernameAsync(It.IsAny<string>()))
+                .Verifiable();
+            _storageService.Setup(m => m.SetAuthTokenAsync(It.IsAny<string>()))
+                .Verifiable();
+            _storageService.Setup(m => m.SetUserIdAsync(It.IsAny<long>()))
+                .Verifiable();
+
+            _navigationService.Setup(m => m.NavigateAsync("/LoginPage"))
+                .ReturnsAsync(new NavigationResult());
+
+            _userDialogs.Setup(m => m.AlertAsync(It.IsAny<AlertConfig>(), null))
+                .Verifiable();
+            
+            // Act
+            _changePasswordViewModel.ChangeCommand.Execute();
+            _scheduler.Start();
+            
+            // Assert
+            Assert.IsFalse(_changePasswordViewModel.IsError, "vm.IsError should be false if login was successful.");
+
+            _restService.Verify();
+            _storageService.Verify();
+            _userDialogs.Verify();
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel.Test/Settings/RequestChangePasswordViewModelTest.cs
+++ b/Sparky.TrakApp.ViewModel.Test/Settings/RequestChangePasswordViewModelTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+using Moq;
+using NUnit.Framework;
+using Prism.Navigation;
+using Sparky.TrakApp.Service;
+using Sparky.TrakApp.Service.Exception;
+using Sparky.TrakApp.ViewModel.Resources;
+using Sparky.TrakApp.ViewModel.Settings;
+
+namespace Sparky.TrakApp.ViewModel.Test.Settings
+{
+    [TestFixture]
+    public class RequestChangePasswordViewModelTest
+    {
+        private Mock<INavigationService> _navigationService;
+        private Mock<IStorageService> _storageService;
+        private Mock<IAuthService> _authService;
+        private TestScheduler _scheduler;
+
+        private RequestChangePasswordViewModel _requestChangePasswordViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _navigationService = new Mock<INavigationService>();
+            _storageService = new Mock<IStorageService>();
+            _authService = new Mock<IAuthService>();
+            _scheduler = new TestScheduler();
+
+            _requestChangePasswordViewModel = new RequestChangePasswordViewModel(_scheduler, _navigationService.Object,
+                _storageService.Object, _authService.Object);
+        }
+
+        [Test]
+        public void SendCommand_ThrowsApiException_SetsErrorMessageAsApiError()
+        {
+            // Arrange
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            _authService.Setup(m => m.RequestChangePasswordAsync(It.IsAny<string>()))
+                .Throws(new ApiException());
+
+            // Act
+            _requestChangePasswordViewModel.SendCommand.Execute().Catch(Observable.Return(Unit.Default)).Subscribe();
+            _scheduler.Start();
+
+            // Assert
+            Assert.IsTrue(_requestChangePasswordViewModel.IsError,
+                "_requestChangePasswordViewModel.IsError should be true if an exception is thrown.");
+            Assert.AreEqual(Messages.ErrorMessageApiError, _requestChangePasswordViewModel.ErrorMessage,
+                "The error message is incorrect.");
+
+            _navigationService.Verify(m => m.NavigateAsync("ChangePasswordPage"), Times.Never);
+        }
+
+        [Test]
+        public void SendCommand_ThrowsException_SetsErrorMessageAsApiError()
+        {
+            // Arrange
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            _authService.Setup(m => m.RequestChangePasswordAsync(It.IsAny<string>()))
+                .Throws(new Exception());
+
+            // Act
+            _requestChangePasswordViewModel.SendCommand.Execute().Catch(Observable.Return(Unit.Default)).Subscribe();
+            _scheduler.Start();
+
+            // Assert
+            Assert.IsTrue(_requestChangePasswordViewModel.IsError,
+                "_requestChangePasswordViewModel.IsError should be true if an exception is thrown.");
+            Assert.AreEqual(Messages.ErrorMessageGeneric, _requestChangePasswordViewModel.ErrorMessage,
+                "The error message is incorrect.");
+
+            _navigationService.Verify(m => m.NavigateAsync("ChangePasswordPage"), Times.Never);
+        }
+
+        [Test]
+        public void SendCommand_WithNoErrors_NavigatesToChangePasswordPage()
+        {
+            // Arrange
+            _storageService.Setup(m => m.GetUsernameAsync())
+                .ReturnsAsync("username");
+
+            _authService.Setup(m => m.RequestChangePasswordAsync(It.IsAny<string>()))
+                .Verifiable();
+
+            _navigationService.Setup(m => m.NavigateAsync("ChangePasswordPage", It.IsAny<INavigationParameters>()));
+
+            // Act
+            _requestChangePasswordViewModel.SendCommand.Execute().Subscribe();
+            _scheduler.Start();
+
+            // Assert
+            Assert.IsFalse(_requestChangePasswordViewModel.IsError,
+                "vm.IsError should be false if login was successful.");
+
+            _authService.Verify();
+            _navigationService.Verify(m => m.NavigateAsync("ChangePasswordPage", It.IsAny<INavigationParameters>()),
+                Times.Once);
+        }
+        
+        [Test]
+        public void ChangePasswordCommand_WithNoData_DoesntThrowException()
+        {
+            _navigationService.Setup(mock => mock.NavigateAsync("ChangePasswordPage", It.IsAny<INavigationParameters>()))
+                .Verifiable();
+            
+            Assert.DoesNotThrow(() =>
+            {
+                // Act
+                _requestChangePasswordViewModel.ChangePasswordCommand.Execute().Subscribe();
+                _scheduler.Start();
+            });    
+            
+            // Assert
+            _navigationService.Verify();
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel.Test/Settings/SettingsViewModelTest.cs
+++ b/Sparky.TrakApp.ViewModel.Test/Settings/SettingsViewModelTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.Reactive.Testing;
+using Moq;
+using NUnit.Framework;
+using Prism.Navigation;
+using Sparky.TrakApp.ViewModel.Settings;
+
+namespace Sparky.TrakApp.ViewModel.Test.Settings
+{
+    [TestFixture]
+    public class SettingsViewModelTest
+    {
+        private Mock<INavigationService> _navigationService;
+        private TestScheduler _scheduler;
+
+        private SettingsViewModel _settingsViewModel;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _navigationService = new Mock<INavigationService>();
+            _scheduler = new TestScheduler();
+
+            _settingsViewModel = new SettingsViewModel(_scheduler, _navigationService.Object);
+        }
+        
+        [Test]
+        public void ChangePasswordCommand_WithNoData_DoesntThrowException()
+        {
+            _navigationService.Setup(mock => mock.NavigateAsync("RequestChangePasswordPage", It.IsAny<INavigationParameters>()))
+                .Verifiable();
+            
+            Assert.DoesNotThrow(() =>
+            {
+                // Act
+                _settingsViewModel.ChangePasswordCommand.Execute().Subscribe();
+                _scheduler.Start();
+            });    
+            
+            // Assert
+            _navigationService.Verify();
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel.Test/Validation/ChangePasswordDetailsValidatorTest.cs
+++ b/Sparky.TrakApp.ViewModel.Test/Validation/ChangePasswordDetailsValidatorTest.cs
@@ -1,0 +1,322 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Sparky.TrakApp.Model.Settings.Validation;
+using Sparky.TrakApp.ViewModel.Resources;
+using Sparky.TrakApp.ViewModel.Validation;
+
+namespace Sparky.TrakApp.ViewModel.Test.Validation
+{
+    [TestFixture]
+    public class ChangePasswordDetailsValidatorTest
+    {
+        [Test]
+        public void Validate_WithNullRecoveryToken_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails());
+
+            // Assert
+            Assert.AreEqual(Messages.RecoveryErrorMessageRecoveryTokenEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for a null recovery token.");
+        }
+
+        [Test]
+        public void Validate_WithEmptyRecoveryToken_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Empty
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RecoveryErrorMessageRecoveryTokenEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for an empty recovery token.");
+        }
+
+        [Test]
+        public void Validate_WithRecoveryTokenContainingWhitespace_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = "token   "
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RecoveryErrorMessageRecoveryTokenWhitespace,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false for a recovery token containing white space.");
+        }
+
+        [Test]
+        public void Validate_WithRecoveryTokenOfIncorrectLength_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = "token"
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RecoveryErrorMessageRecoveryTokenLength,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false if a recovery token is not 30 characters long.");
+        }
+
+        [Test]
+        public void Validate_WithRecoveryTokenWithNonAlphaNumericCharacters_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 29)) + "@"
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RecoveryErrorMessageRecoveryTokenAlphanumeric,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false if a recovery token contains non-alphanumeric characters.");
+        }
+
+        
+        [Test]
+        public void Validate_WithNullNewPassword_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                ConfirmNewPassword = "Password123"
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for a null new password.");
+        }
+
+        [Test]
+        public void Validate_WithEmptyNewPassword_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = string.Empty,
+                ConfirmNewPassword = "Password123"
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for an empty new password.");
+        }
+
+        [Test]
+        public void Validate_WithNewPasswordLessThanEightCharacters_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Less1",
+                ConfirmNewPassword = "Password123"
+            });
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordMinimumLength,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false if the new password is less than eight characters.");
+        }
+
+        [Test]
+        public void Validate_WithNewPasswordWithNoUppercaseCharacters_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "password123",
+                ConfirmNewPassword = "Password123"
+            });
+            
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordUppercaseCharacter,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false if the new password has no uppercase characters.");
+        }
+
+        [Test]
+        public void Validate_WithNewPasswordWithNoLowercaseCharacters_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "PASSWORD123",
+                ConfirmNewPassword = "Password123"
+            });
+            
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordLowercaseCharacter,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid,
+                "result.IsValid should be false if the new password has no lowercase characters.");
+        }
+
+        [Test]
+        public void Validate_WithNewPasswordWithNoNumbers_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "PasswordIsLong",
+                ConfirmNewPassword = "Password123"
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordNumber,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false if the new password has no numbers.");
+        }
+
+        [Test]
+        public void Validate_WithNewPasswordContainingWhitespace_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Password 123",
+                ConfirmNewPassword = "Password123"
+            });
+            
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessagePasswordWhitespace,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false if the new password contains whitespace.");
+        }
+
+        [Test]
+        public void Validate_WithNullConfirmNewPassword_ValidationFails()
+        {
+            // Arrange
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Password123"
+            });
+            
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessageConfirmPasswordEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for a null confirm new password.");
+        }
+
+        [Test]
+        public void Validate_WithEmptyConfirmNewPassword_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Password123",
+                ConfirmNewPassword = string.Empty
+            });
+
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessageConfirmPasswordEmpty,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false for an empty confirm new password.");
+        }
+
+        [Test]
+        public void Validate_WithNonMatchingConfirmNewPassword_ValidationFails()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Password1234",
+                ConfirmNewPassword = "Password123"
+            });
+            
+            // Assert
+            Assert.AreEqual(Messages.RegistrationErrorMessageConfirmPasswordMismatch,
+                result.Errors.First().ErrorMessage);
+            Assert.IsFalse(result.IsValid, "result.IsValid should be false if the passwords don't match.");
+        }
+
+        [Test]
+        public void Validate_WithValidRegistrationDetails_ValidationPasses()
+        {
+            // Arrange
+            var validator = new ChangePasswordDetailsValidator();
+
+            // Act
+            var result = validator.Validate(new ChangePasswordDetails
+            {
+                RecoveryToken = string.Concat(Enumerable.Repeat("a", 30)),
+                NewPassword = "Password123",
+                ConfirmNewPassword = "Password123"
+            });
+
+            // Assert
+            Assert.IsTrue(result.IsValid, "result.IsValid should be true if validation was successful.");
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel/BaseMasterDetailViewModel.cs
+++ b/Sparky.TrakApp.ViewModel/BaseMasterDetailViewModel.cs
@@ -38,7 +38,8 @@ namespace Sparky.TrakApp.ViewModel
 
             LoadHomeCommand = ReactiveCommand.CreateFromTask(LoadHomeAsync, outputScheduler: scheduler);
             LoadGamesCommand = ReactiveCommand.CreateFromTask(LoadGamesAsync, outputScheduler: scheduler);
-
+            LoadSettingsCommand = ReactiveCommand.CreateFromTask(LoadSettingsAsync, outputScheduler: scheduler);
+            
             LogoutCommand = ReactiveCommand.CreateFromTask(LogoutAsync, outputScheduler: scheduler);
             // Not much if the logout fails, just still go to the login page.
             LogoutCommand.ThrownExceptions.Subscribe(async ex =>
@@ -60,6 +61,12 @@ namespace Sparky.TrakApp.ViewModel
         /// </summary>
         public ReactiveCommand<Unit, Unit> LoadGamesCommand { get; }
 
+        /// <summary>
+        /// Command that is invoked each time the settings label is tapped by the user on the view.
+        /// When called, the command will propagate the request and call the <see cref="LoadSettingsAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> LoadSettingsCommand { get; }
+        
         /// <summary>
         /// Command that is invoked each time the logout label is tapped by the user on the view.
         /// When called, the command will propagate the request and call the <see cref="LogoutAsync"/> method.
@@ -86,6 +93,16 @@ namespace Sparky.TrakApp.ViewModel
             await NavigationService.NavigateAsync("BaseNavigationPage/GameUserEntriesTabbedPage");
         }
 
+        /// <summary>
+        /// Private method that is invoked by the <see cref="LoadSettingsCommand"/>. When called, it will navigate
+        /// the user to the games page.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task LoadSettingsAsync()
+        {
+            await NavigationService.NavigateAsync("BaseNavigationPage/SettingsPage");
+        }
+        
         /// <summary>
         /// Private method that invoked by the <see cref="LogoutCommand"/>. When called, it will remove all of the
         /// personal identifiable information from the <see cref="IStorageService"/> and remove the notification token

--- a/Sparky.TrakApp.ViewModel/Login/ForgottenPasswordViewModel.cs
+++ b/Sparky.TrakApp.ViewModel/Login/ForgottenPasswordViewModel.cs
@@ -2,15 +2,12 @@
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using FluentValidation;
 using Microsoft.AppCenter.Crashes;
 using Plugin.FluentValidationRules;
-using Prism.Commands;
 using Prism.Navigation;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
-using Sparky.TrakApp.Model.Login;
 using Sparky.TrakApp.Model.Login.Validation;
 using Sparky.TrakApp.Service;
 using Sparky.TrakApp.Service.Exception;

--- a/Sparky.TrakApp.ViewModel/Resources/Messages.Designer.cs
+++ b/Sparky.TrakApp.ViewModel/Resources/Messages.Designer.cs
@@ -178,6 +178,69 @@ namespace Sparky.TrakApp.ViewModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change.
+        /// </summary>
+        public static string ChangePasswordPageChange {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageChange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm new password.
+        /// </summary>
+        public static string ChangePasswordPageConfirmNewPassword {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageConfirmNewPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current password.
+        /// </summary>
+        public static string ChangePasswordPageCurrentPassword {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageCurrentPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New password.
+        /// </summary>
+        public static string ChangePasswordPageNewPassword {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageNewPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset token.
+        /// </summary>
+        public static string ChangePasswordPageResetToken {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageResetToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password successfully changed. Please login with your new credentials..
+        /// </summary>
+        public static string ChangePasswordPageSuccess {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change password.
+        /// </summary>
+        public static string ChangePasswordPageTitle {
+            get {
+                return ResourceManager.GetString("ChangePasswordPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Done.
         /// </summary>
         public static string Done {
@@ -1137,6 +1200,78 @@ namespace Sparky.TrakApp.ViewModel.Resources {
         public static string RegistrationErrorMessageUsernameWhitespace {
             get {
                 return ResourceManager.GetString("RegistrationErrorMessageUsernameWhitespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Already have a token?.
+        /// </summary>
+        public static string RequestChangePasswordPageAlreadyHaveToken {
+            get {
+                return ResourceManager.GetString("RequestChangePasswordPageAlreadyHaveToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tap below to receive your token to change your password..
+        /// </summary>
+        public static string RequestChangePasswordPageInstructions {
+            get {
+                return ResourceManager.GetString("RequestChangePasswordPageInstructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Send.
+        /// </summary>
+        public static string RequestChangePasswordPageSend {
+            get {
+                return ResourceManager.GetString("RequestChangePasswordPageSend", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tap here.
+        /// </summary>
+        public static string RequestChangePasswordPageTapHere {
+            get {
+                return ResourceManager.GetString("RequestChangePasswordPageTapHere", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Request change password.
+        /// </summary>
+        public static string RequestChangePasswordPageTitle {
+            get {
+                return ResourceManager.GetString("RequestChangePasswordPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Account.
+        /// </summary>
+        public static string SettingsPageAccountSubtitle {
+            get {
+                return ResourceManager.GetString("SettingsPageAccountSubtitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change password.
+        /// </summary>
+        public static string SettingsPageChangePassword {
+            get {
+                return ResourceManager.GetString("SettingsPageChangePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings.
+        /// </summary>
+        public static string SettingsPageTitle {
+            get {
+                return ResourceManager.GetString("SettingsPageTitle", resourceCulture);
             }
         }
         

--- a/Sparky.TrakApp.ViewModel/Resources/Messages.resx
+++ b/Sparky.TrakApp.ViewModel/Resources/Messages.resx
@@ -414,4 +414,49 @@
 	<data name="GameUserEntriesTabbedPageTitle" xml:space="preserve">
 		<value>Games</value>
 	</data>
+	<data name="SettingsPageTitle" xml:space="preserve">
+		<value>Settings</value>
+	</data>
+	<data name="SettingsPageAccountSubtitle" xml:space="preserve">
+		<value>Account</value>
+	</data>
+	<data name="SettingsPageChangePassword" xml:space="preserve">
+		<value>Change password</value>
+	</data>
+	<data name="ChangePasswordPageTitle" xml:space="preserve">
+		<value>Change password</value>
+	</data>
+	<data name="ChangePasswordPageCurrentPassword" xml:space="preserve">
+		<value>Current password</value>
+	</data>
+	<data name="ChangePasswordPageNewPassword" xml:space="preserve">
+		<value>New password</value>
+	</data>
+	<data name="ChangePasswordPageConfirmNewPassword" xml:space="preserve">
+		<value>Confirm new password</value>
+	</data>
+	<data name="ChangePasswordPageChange" xml:space="preserve">
+		<value>Change</value>
+	</data>
+	<data name="ChangePasswordPageResetToken" xml:space="preserve">
+		<value>Reset token</value>
+	</data>
+	<data name="RequestChangePasswordPageTitle" xml:space="preserve">
+		<value>Request change password</value>
+	</data>
+	<data name="RequestChangePasswordPageInstructions" xml:space="preserve">
+		<value>Tap below to receive your token to change your password.</value>
+	</data>
+	<data name="RequestChangePasswordPageSend" xml:space="preserve">
+		<value>Send</value>
+	</data>
+	<data name="RequestChangePasswordPageAlreadyHaveToken" xml:space="preserve">
+		<value>Already have a token?</value>
+	</data>
+	<data name="RequestChangePasswordPageTapHere" xml:space="preserve">
+		<value>Tap here</value>
+	</data>
+	<data name="ChangePasswordPageSuccess" xml:space="preserve">
+		<value>Password successfully changed. Please login with your new credentials.</value>
+	</data>
 </root>

--- a/Sparky.TrakApp.ViewModel/Settings/ChangePasswordViewModel.cs
+++ b/Sparky.TrakApp.ViewModel/Settings/ChangePasswordViewModel.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Threading.Tasks;
+using Acr.UserDialogs;
+using FluentValidation;
+using Microsoft.AppCenter.Crashes;
+using Plugin.FluentValidationRules;
+using Prism.Navigation;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using Sparky.TrakApp.Model.Settings;
+using Sparky.TrakApp.Model.Settings.Validation;
+using Sparky.TrakApp.Service;
+using Sparky.TrakApp.Service.Exception;
+using Sparky.TrakApp.ViewModel.Common;
+using Sparky.TrakApp.ViewModel.Resources;
+using Sparky.TrakApp.ViewModel.Validation;
+
+namespace Sparky.TrakApp.ViewModel.Settings
+{
+    /// <summary>
+    /// The <see cref="ChangePasswordViewModel"/> is a view model that is associated with the change password page view.
+    /// Its responsibility is to respond to change password attempts made with credential information.
+    ///
+    /// The <see cref="ChangePasswordViewModel"/> also provides methods to validate fields on the change password page view.
+    /// Any validation errors or generic errors are stored within the view model for use on the view.
+    /// </summary>
+    public class ChangePasswordViewModel : ReactiveViewModel, IValidate<ChangePasswordDetails>
+    {
+        private readonly IStorageService _storageService;
+        private readonly IRestService _restService;
+        private readonly IAuthService _authService;
+        private readonly IUserDialogs _userDialogs;
+
+        private IValidator _validator;
+        private Validatables _validatables;
+
+        /// <summary>
+        /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.
+        /// The constructors should never be invoked outside of the Prism DI framework. All instantiation
+        /// should be handled by the framework.
+        /// </summary>
+        /// <param name="scheduler">The <see cref="IScheduler"/> instance to inject.</param>
+        /// <param name="navigationService">The <see cref="INavigationService"/> instance to inject.</param>
+        /// <param name="storageService">The <see cref="IStorageService"/> instance to inject.</param>
+        /// <param name="restService">The <see cref="IRestService"/> instance to inject.</param>
+        /// <param name="authService">The <see cref="IAuthService"/> instance to inject.</param>
+        /// <param name="userDialogs">The <see cref="IUserDialogs"/> instance to inject.</param>
+        public ChangePasswordViewModel(IScheduler scheduler, INavigationService navigationService,
+            IStorageService storageService, IRestService restService, IAuthService authService,
+            IUserDialogs userDialogs) : base(scheduler, navigationService)
+        {
+            _storageService = storageService;
+            _restService = restService;
+            _authService = authService;
+            _userDialogs = userDialogs;
+
+            SetupForValidation();
+
+            ClearValidationCommand = ReactiveCommand.Create<string>(ClearValidation);
+
+            ChangeCommand = ReactiveCommand.CreateFromTask(ChangeAsync, outputScheduler: scheduler);
+            // Report errors if an exception was thrown.
+            ChangeCommand.ThrownExceptions.Subscribe(ex =>
+            {
+                IsError = true;
+
+                if (ex is ApiException)
+                {
+                    ErrorMessage = Messages.ErrorMessageApiError;
+                }
+                else
+                {
+                    ErrorMessage = Messages.ErrorMessageGeneric;
+                    Crashes.TrackError(ex);
+                }
+            });
+            
+            this.WhenAnyObservable(x => x.ChangeCommand.IsExecuting)
+                .ToPropertyEx(this, x => x.IsLoading);
+        }
+
+        /// <summary>
+        /// A <see cref="Validatable{T}"/> that contains the currently populated reset token with
+        /// additional validation information.
+        /// </summary>
+        public Validatable<string> ResetToken { get; private set; }
+
+        /// <summary>
+        /// A <see cref="Validatable{T}"/> that contains the currently populated new password with
+        /// additional validation information.
+        /// </summary>
+        [Reactive]
+        public Validatable<string> NewPassword { get; private set; }
+
+        /// <summary>
+        /// A <see cref="Validatable{T}"/> that contains the currently populated confirm new password with
+        /// additional validation information.
+        /// </summary>
+        [Reactive]
+        public Validatable<string> ConfirmNewPassword { get; private set; }
+
+        /// <summary>
+        /// Command that is invoked each time that the validatable field on the view is changed, which
+        /// for the <see cref="ChangePasswordViewModel"/> is the <see cref="NewPassword"/> and <see cref="ConfirmNewPassword"/>.
+        /// When the view is changed, the name is passed through and the request propagated to the
+        /// <see cref="ClearValidation"/> methods.
+        /// </summary>
+        public ReactiveCommand<string, Unit> ClearValidationCommand { get; }
+
+        /// <summary>
+        /// Command that is invoked by the view when the send button is tapped. When called, the command
+        /// will propagate the request and call the <see cref="ChangeAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ChangeCommand { get; }
+
+        /// <summary>
+        /// Invoked within the constructor of the <see cref="ChangePasswordViewModel"/>, its' responsibility is to
+        /// instantiate the <see cref="AbstractValidator{T}"/> and the validatable values that will need to
+        /// meet the specified criteria within the <see cref="ChangePasswordDetailsValidator"/> to pass validation.
+        /// </summary>
+        public void SetupForValidation()
+        {
+            ResetToken = new Validatable<string>(nameof(ChangePasswordDetails.RecoveryToken));
+            NewPassword = new Validatable<string>(nameof(ChangePasswordDetails.NewPassword));
+            ConfirmNewPassword = new Validatable<string>(nameof(ChangePasswordDetails.ConfirmNewPassword));
+
+            _validator = new ChangePasswordDetailsValidator();
+            _validatables = new Validatables(ResetToken, NewPassword, ConfirmNewPassword);
+        }
+
+        /// <summary>
+        /// Validates the specified <see cref="ChangePasswordDetails"/> model with the validation rules specified within
+        /// this class, which are contained within the <see cref="ForgottenPasswordDetailsValidator"/>. The results, regardless
+        /// of whether they are true or false are applied to the validatable variable. 
+        /// </summary>
+        /// <param name="model">The <see cref="ChangePasswordDetails"/> instance to validate against the <see cref="ChangePasswordDetailsValidator"/>.</param>
+        /// <returns>A <see cref="OverallValidationResult"/> which will contain a list of any errors.</returns>
+        public OverallValidationResult Validate(ChangePasswordDetails model)
+        {
+            return _validator.Validate(model)
+                .ApplyResultsTo(_validatables);
+        }
+
+        /// <summary>
+        /// Clears the validation information for the specified variable within this <see cref="ChangePasswordViewModel"/>.
+        /// If the clear options are sent through as an empty string, all validation information within this
+        /// view model is cleared.
+        /// </summary>
+        /// <param name="clearOptions">Which validation information to clear from the context.</param>
+        public void ClearValidation(string clearOptions = "")
+        {
+            _validatables.Clear(clearOptions);
+        }
+
+        /// <summary>
+        /// Private method that is invoked by the <see cref="ChangeCommand"/> when activated by the associated
+        /// view. This method will validate the new password and its confirmation on the view, and if valid attempt
+        /// to change the password for currently authenticated user. If the request is successful, the user is logged out
+        /// and presented with an alert message on the login page stating they'll need to login with their new credentials.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task ChangeAsync()
+        {
+            IsError = false;
+
+            var changePasswordDetails = _validatables.Populate<ChangePasswordDetails>();
+            var validationResult = Validate(changePasswordDetails);
+
+            if (validationResult.IsValidOverall)
+            {
+                await ExecuteChangeAsync();
+            }
+        }
+
+        /// <summary>
+        /// Private method invoked by the <see cref="ChangeAsync"/> method. When called it will call off to the API
+        /// and attempt to change the users password. If the password changing was successful, the data within the storage
+        /// service will be removed and the user will be re-directed back to the login page, prompting them to login with
+        /// their new credentials.
+        ///
+        /// If the call to the API was unsuccessful, an error message will be prompted to the user telling them to try
+        /// again.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task ExecuteChangeAsync()
+        {
+            // Get details from the storage service.
+            var username = await _storageService.GetUsernameAsync();
+
+            // Send the request to try and change the password.
+            var response = await _authService.ChangePasswordAsync(new ChangePasswordRequest
+            {
+                Username = username,
+                NewPassword = NewPassword.Value,
+                RecoveryToken = ResetToken.Value
+            });
+
+            // If there are errors, it's either due to the user not being found, the password not matching the criteria 
+            // or the recovery token entered was incorrect.
+            if (response.Error)
+            {
+                IsError = true;
+                ErrorMessage = response.ErrorMessage;
+            }
+            else
+            {
+                // Password changing was successful, continue with standard log out procedure. 
+                var userId = await _storageService.GetUserIdAsync();
+                var deviceId = await _storageService.GetDeviceIdAsync();
+
+                // Need to ensure the correct details are registered for push notifications.
+                await _restService.DeleteAsync(
+                    $"notifications/unregister?user-id={userId}&device-guid={deviceId}");
+
+                // Remove all of the identifiable information from the secure store.
+                await _storageService.SetUsernameAsync(string.Empty);
+                await _storageService.SetAuthTokenAsync(string.Empty);
+                await _storageService.SetUserIdAsync(0);
+
+                // Navigate back to the login page.
+                await NavigationService.NavigateAsync("/LoginPage");
+
+                var alertConfig = new AlertConfig()
+                    .SetTitle(Messages.TrakTitle)
+                    .SetMessage(Messages.ChangePasswordPageSuccess);
+
+                await _userDialogs.AlertAsync(alertConfig);
+            }
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel/Settings/RequestChangePasswordViewModel.cs
+++ b/Sparky.TrakApp.ViewModel/Settings/RequestChangePasswordViewModel.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Threading.Tasks;
+using Microsoft.AppCenter.Crashes;
+using Prism.Navigation;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using Sparky.TrakApp.Common;
+using Sparky.TrakApp.Service;
+using Sparky.TrakApp.Service.Exception;
+using Sparky.TrakApp.ViewModel.Common;
+using Sparky.TrakApp.ViewModel.Resources;
+
+namespace Sparky.TrakApp.ViewModel.Settings
+{
+    /// <summary>
+    /// The <see cref="RequestChangePasswordViewModel"/> is a simple view model that responds to event
+    /// propagated by the request change password page. It's mainly contains one element of functionality,
+    /// which is to dispatch change password emails to the currently logged in users' email address, which
+    /// allows the user to actually reset their password.
+    /// </summary>
+    public class RequestChangePasswordViewModel : ReactiveViewModel
+    {
+        private readonly IStorageService _storageService;
+        private readonly IAuthService _authService;
+
+        /// <summary>
+        /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.
+        /// The constructors should never be invoked outside of the Prism DI framework. All instantiation
+        /// should be handled by the framework.
+        /// </summary>
+        /// <param name="scheduler">The <see cref="IScheduler"/> instance to inject.</param>
+        /// <param name="navigationService">The <see cref="INavigationService"/> instance to inject.</param>
+        /// <param name="storageService">The <see cref="IStorageService"/> instance to inject.</param>
+        /// <param name="authService">The <see cref="IAuthService"/> instance to inject.</param>
+        public RequestChangePasswordViewModel(IScheduler scheduler, INavigationService navigationService,
+            IStorageService storageService, IAuthService authService) : base(scheduler, navigationService)
+        {
+            _storageService = storageService;
+            _authService = authService;
+
+            SendCommand = ReactiveCommand.CreateFromTask(SendAsync, outputScheduler: scheduler);
+            // Report errors if an exception was thrown.
+            SendCommand.ThrownExceptions.Subscribe(ex =>
+            {
+                IsError = true;
+                if (ex is ApiException)
+                {
+                    ErrorMessage = Messages.ErrorMessageApiError;
+                }
+                else
+                {
+                    ErrorMessage = Messages.ErrorMessageGeneric;
+                    Crashes.TrackError(ex);
+                }
+            });
+
+            ChangePasswordCommand = ReactiveCommand.CreateFromTask(ChangePasswordAsync, outputScheduler: scheduler);
+
+            this.WhenAnyObservable(x => x.SendCommand.IsExecuting)
+                .ToPropertyEx(this, x => x.IsLoading);
+        }
+
+        /// <summary>
+        /// Command that is invoked by the view when the send button is tapped. When called, the command
+        /// will propagate the request and call the <see cref="SendAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> SendCommand { get; }
+
+        /// <summary>
+        /// Command that is invoked by the view when the already got a token label is tapped. When called,
+        /// the command will propagate the request and call the <see cref="ChangePasswordAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ChangePasswordCommand { get; }
+
+        /// <summary>
+        /// Invoked when the <see cref="SendCommand"/> is invoked by the view. The method will attempt
+        /// to send an email to the email address registered against this user with a recovery token which
+        /// will be needed when changing their password. If the call is successful, the user will be
+        /// redirected to the change password page.
+        ///
+        /// If the call is unsuccessful, the user will not be re-directed and an error message will be
+        /// presented to the user prompted them to dry again.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task SendAsync()
+        {
+            IsError = false;
+
+            var username = await _storageService.GetUsernameAsync();
+
+            await _authService.RequestChangePasswordAsync(username);
+            await NavigationService.NavigateAsync("ChangePasswordPage", new NavigationParameters
+            {
+                { "transition-type", TransitionType.SlideFromBottom }
+            });
+        }
+
+        /// <summary>
+        /// Invoked when the <see cref="ChangePasswordCommand"/> is invoked by the view. All the method will do is
+        /// navigate to the change password page..
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task ChangePasswordAsync()
+        {
+            await NavigationService.NavigateAsync("ChangePasswordPage", new NavigationParameters
+            {
+                { "transition-type", TransitionType.SlideFromBottom }
+            });
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel/Settings/SettingsViewModel.cs
+++ b/Sparky.TrakApp.ViewModel/Settings/SettingsViewModel.cs
@@ -1,0 +1,48 @@
+﻿using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Threading.Tasks;
+using Prism.Navigation;
+using ReactiveUI;
+using Sparky.TrakApp.Common;
+using Sparky.TrakApp.ViewModel.Common;
+
+namespace Sparky.TrakApp.ViewModel.Settings
+{
+    /// <summary>
+    /// The <see cref="SettingsViewModel"/> is a simple view model whose sole responsibility is to
+    /// response to tap events on the settings page and redirect the user to the requested page.
+    /// </summary>
+    public class SettingsViewModel : ReactiveViewModel
+    {
+        /// <summary>
+        /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.
+        /// The constructors should never be invoked outside of the Prism DI framework. All instantiation
+        /// should be handled by the framework.
+        /// </summary>
+        /// <param name="scheduler">The <see cref="IScheduler"/> instance to inject.</param>
+        /// <param name="navigationService">The <see cref="INavigationService"/> instance to inject.</param>
+        public SettingsViewModel(IScheduler scheduler, INavigationService navigationService) : base(scheduler, navigationService)
+        {
+            ChangePasswordCommand = ReactiveCommand.CreateFromTask(ChangePasswordAsync, outputScheduler: scheduler);
+        }
+        
+        /// <summary>
+        /// Command that is invoked each the time the change password label is tapped by the user on the view.
+        /// When called, the command will propagate the request and call the <see cref="ChangePasswordAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ChangePasswordCommand { get; }
+
+        /// <summary>
+        /// Private method that is invoked by the <see cref="ChangePasswordCommand"/> when activated by the associated
+        /// view. This method will navigate the user to the change password page.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task ChangePasswordAsync()
+        {
+            await NavigationService.NavigateAsync("RequestChangePasswordPage", new NavigationParameters
+            {
+                { "transition-type", TransitionType.SlideFromRight }
+            });
+        }
+    }
+}

--- a/Sparky.TrakApp.ViewModel/Validation/ChangePasswordDetailsValidator.cs
+++ b/Sparky.TrakApp.ViewModel/Validation/ChangePasswordDetailsValidator.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using FluentValidation;
+using Sparky.TrakApp.Model.Settings.Validation;
+using Sparky.TrakApp.ViewModel.Resources;
+
+namespace Sparky.TrakApp.ViewModel.Validation
+{
+    /// <summary>
+    /// The <see cref="ChangePasswordDetailsValidator"/> is a validation class that validates the properties
+    /// within the <see cref="ChangePasswordDetails"/> class to ensure that they can valid information before
+    /// being passed onto an API call.
+    /// </summary>
+    public class ChangePasswordDetailsValidator : AbstractValidator<ChangePasswordDetails>
+    {
+        public ChangePasswordDetailsValidator()
+        {
+            RuleFor(r => r.RecoveryToken)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithMessage(Messages.RecoveryErrorMessageRecoveryTokenEmpty)
+                .Must(p => !p.Any(char.IsWhiteSpace))
+                .WithMessage(Messages.RecoveryErrorMessageRecoveryTokenWhitespace)
+                .Length(30)
+                .WithMessage(Messages.RecoveryErrorMessageRecoveryTokenLength)
+                .Matches("^[a-zA-Z][a-zA-Z0-9]*$")
+                .WithMessage(Messages.RecoveryErrorMessageRecoveryTokenAlphanumeric);
+            
+            RuleFor(r => r.NewPassword)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithMessage(Messages.RegistrationErrorMessagePasswordEmpty)
+                .MinimumLength(8)
+                .WithMessage(Messages.RegistrationErrorMessagePasswordMinimumLength)
+                .Matches("[A-Z]")
+                .WithMessage(Messages.RegistrationErrorMessagePasswordUppercaseCharacter)
+                .Matches("[a-z]")
+                .WithMessage(Messages.RegistrationErrorMessagePasswordLowercaseCharacter)
+                .Matches("[0-9]")
+                .WithMessage(Messages.RegistrationErrorMessagePasswordNumber)
+                .Must(p => !p.Any(char.IsWhiteSpace))
+                .WithMessage(Messages.RegistrationErrorMessagePasswordWhitespace);
+
+            RuleFor(r => r.ConfirmNewPassword)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithMessage(Messages.RegistrationErrorMessageConfirmPasswordEmpty)
+                .Must((model, field) => string.Equals(model.NewPassword, field))
+                .WithMessage(Messages.RegistrationErrorMessageConfirmPasswordMismatch);
+        }
+    }
+}

--- a/Sparky.TrakApp/App.xaml.cs
+++ b/Sparky.TrakApp/App.xaml.cs
@@ -16,9 +16,11 @@ using Sparky.TrakApp.Service;
 using Sparky.TrakApp.ViewModel;
 using Sparky.TrakApp.ViewModel.Games;
 using Sparky.TrakApp.ViewModel.Login;
+using Sparky.TrakApp.ViewModel.Settings;
 using Sparky.TrakApp.Views;
 using Sparky.TrakApp.Views.Games;
 using Sparky.TrakApp.Views.Login;
+using Sparky.TrakApp.Views.Settings;
 
 namespace Sparky.TrakApp
 {
@@ -79,7 +81,12 @@ namespace Sparky.TrakApp
 
             // Home pages
             containerRegistry.RegisterForNavigation<HomePage, HomeViewModel>();
-
+            
+            // Settings pages
+            containerRegistry.RegisterForNavigation<SettingsPage, SettingsViewModel>();
+            containerRegistry.RegisterForNavigation<ChangePasswordPage, ChangePasswordViewModel>();
+            containerRegistry.RegisterForNavigation<RequestChangePasswordPage, RequestChangePasswordViewModel>();
+            
             // Game pages
             containerRegistry.Register<GameUserEntryBacklogListViewModel>();
             containerRegistry.Register<GameUserEntryInProgressListViewModel>();

--- a/Sparky.TrakApp/Views/BaseMasterDetailContentPage.xaml
+++ b/Sparky.TrakApp/Views/BaseMasterDetailContentPage.xaml
@@ -86,7 +86,11 @@
                     <Label
                         FontSize="48"
                         Style="{StaticResource TitleLabelStyle}"
-                        Text="{extensions:Translate BaseMasterDetailContentPageSettings}" />
+                        Text="{extensions:Translate BaseMasterDetailContentPageSettings}">
+                        <Label.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding LoadSettingsCommand}" NumberOfTapsRequired="1" />
+                        </Label.GestureRecognizers>
+                    </Label>
                     <!--  Logout label  -->
                     <Label
                         FontSize="48"

--- a/Sparky.TrakApp/Views/Settings/ChangePasswordPage.xaml
+++ b/Sparky.TrakApp/Views/Settings/ChangePasswordPage.xaml
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:BaseContentPage
+    x:Class="Sparky.TrakApp.Views.Settings.ChangePasswordPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:behaviors="http://prismlibrary.com"
+    xmlns:controls="clr-namespace:Sparky.TrakApp.Controls;assembly=Sparky.TrakApp"
+    xmlns:extensions="clr-namespace:Sparky.TrakApp.Extensions;assembly=Sparky.TrakApp"
+    xmlns:settings="clr-namespace:Sparky.TrakApp.ViewModel.Settings;assembly=Sparky.TrakApp.ViewModel"
+    Title="{extensions:Translate ChangePasswordPageTitle}"
+    x:DataType="settings:ChangePasswordViewModel">
+    <controls:BaseContentPage.Content>
+        <ScrollView>
+            <Grid Padding="35">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="1*" />
+                </Grid.ColumnDefinitions>
+                <!--  App logo  -->
+                <Image
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="0,75,0,10"
+                    Source="logo.png" />
+                <!--  Subtitle  -->
+                <ScrollView
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Margin="0,-20,0,0"
+                    HorizontalOptions="Fill"
+                    HorizontalScrollBarVisibility="Never"
+                    Orientation="Horizontal"
+                    VerticalOptions="Start"
+                    VerticalScrollBarVisibility="Never">
+                    <Label Style="{StaticResource SubtitleLabelStyle}" Text="{extensions:Translate Subtitle}" />
+                </ScrollView>
+                <StackLayout
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2">
+                    <!--  Reset token label and entry box.  -->
+                    <Label Style="{StaticResource EntryLabelStyle}" Text="{extensions:Translate ChangePasswordPageResetToken}" />
+                    <controls:BorderedEntry
+                        AutomationId="ChangePasswordPageResetTokenEntry"
+                        BorderColor="{StaticResource TrakWhite}"
+                        BorderThickness="1"
+                        Text="{Binding ResetToken.Value}">
+                        <controls:BorderedEntry.Behaviors>
+                            <behaviors:EventToCommandBehavior
+                                Command="{Binding ClearValidationCommand}"
+                                CommandParameter="ResetToken"
+                                EventName="Focused" />
+                        </controls:BorderedEntry.Behaviors>
+                        <controls:BorderedEntry.Triggers>
+                            <DataTrigger
+                                Binding="{Binding ResetToken.IsValid}"
+                                TargetType="controls:BorderedEntry"
+                                Value="False">
+                                <Setter Property="BorderColor" Value="Red" />
+                            </DataTrigger>
+                        </controls:BorderedEntry.Triggers>
+                    </controls:BorderedEntry>
+                    <!--  Recovery token validation errors  -->
+                    <Label
+                        IsEnabled="{Binding ResetToken.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        IsVisible="{Binding ResetToken.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        Style="{StaticResource ValidationLabelStyle}"
+                        Text="{Binding ResetToken.FirstError}" />
+                    
+                    <!--  Password rules.  -->
+                    <StackLayout>
+                        <Label FontAttributes="Bold" Text="{extensions:Translate PasswordRulesHeader}" />
+                        <Label FontSize="Small" Text="{extensions:Translate PasswordRuleOne}" />
+                        <Label FontSize="Small" Text="{extensions:Translate PasswordRuleTwo}" />
+                        <Label FontSize="Small" Text="{extensions:Translate PasswordRuleThree}" />
+                        <Label FontSize="Small" Text="{extensions:Translate PasswordRuleFour}" />
+                    </StackLayout>
+                    
+                    <!--  New password label and entry box.  -->
+                    <Label
+                        Margin="0,0,0,5"
+                        Style="{StaticResource EntryLabelStyle}"
+                        Text="{extensions:Translate ChangePasswordPageNewPassword}" />
+                    <controls:BorderedEntry
+                        AutomationId="ChangePasswordPageNewPasswordEntry"
+                        BorderColor="{StaticResource TrakWhite}"
+                        BorderThickness="1"
+                        IsPassword="True"
+                        Text="{Binding NewPassword.Value}">
+                        <controls:BorderedEntry.Behaviors>
+                            <behaviors:EventToCommandBehavior
+                                Command="{Binding ClearValidationCommand}"
+                                CommandParameter="CurrentPassword"
+                                EventName="Focused" />
+                        </controls:BorderedEntry.Behaviors>
+                        <controls:BorderedEntry.Triggers>
+                            <DataTrigger
+                                Binding="{Binding NewPassword.IsValid}"
+                                TargetType="controls:BorderedEntry"
+                                Value="False">
+                                <Setter Property="BorderColor" Value="{StaticResource TrakRed}" />
+                            </DataTrigger>
+                        </controls:BorderedEntry.Triggers>
+                    </controls:BorderedEntry>
+                    <Label
+                        AutomationId="ChangePasswordPageCurrentPasswordErrorLabel"
+                        IsEnabled="{Binding NewPassword.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        IsVisible="{Binding NewPassword.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        Style="{StaticResource ValidationLabelStyle}"
+                        Text="{Binding NewPassword.FirstError}" />
+                    
+                    <!--  Confirm new password label and entry box.  -->
+                    <Label
+                        Margin="0,0,0,5"
+                        Style="{StaticResource EntryLabelStyle}"
+                        Text="{extensions:Translate ChangePasswordPageConfirmNewPassword}" />
+                    <controls:BorderedEntry
+                        AutomationId="ChangePasswordPageConfirmNewPasswordEntry"
+                        BorderColor="{StaticResource TrakWhite}"
+                        BorderThickness="1"
+                        IsPassword="True"
+                        Text="{Binding ConfirmNewPassword.Value}">
+                        <controls:BorderedEntry.Behaviors>
+                            <behaviors:EventToCommandBehavior
+                                Command="{Binding ClearValidationCommand}"
+                                CommandParameter="CurrentPassword"
+                                EventName="Focused" />
+                        </controls:BorderedEntry.Behaviors>
+                        <controls:BorderedEntry.Triggers>
+                            <DataTrigger
+                                Binding="{Binding ConfirmNewPassword.IsValid}"
+                                TargetType="controls:BorderedEntry"
+                                Value="False">
+                                <Setter Property="BorderColor" Value="{StaticResource TrakRed}" />
+                            </DataTrigger>
+                        </controls:BorderedEntry.Triggers>
+                    </controls:BorderedEntry>
+                    <Label
+                        AutomationId="ChangePasswordPagePageCurrentPasswordErrorLabel"
+                        IsEnabled="{Binding ConfirmNewPassword.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        IsVisible="{Binding ConfirmNewPassword.IsValid, Converter={StaticResource NegateBooleanConverter}}"
+                        Style="{StaticResource ValidationLabelStyle}"
+                        Text="{Binding ConfirmNewPassword.FirstError}" />
+
+                    <!--  Display error messages if anything went wrong.  -->
+                    <Label
+                        Margin="0,5"
+                        AutomationId="ChangePasswordPageErrorMessage"
+                        IsEnabled="{Binding IsError}"
+                        IsVisible="{Binding IsError}"
+                        Style="{StaticResource ValidationLabelStyle}"
+                        Text="{Binding ErrorMessage}" />
+
+                    <!--  Verify button and activity indicator.  -->
+                    <Button
+                        Margin="0,20,0,0"
+                        AutomationId="ChangePasswordPageSendButton"
+                        Command="{Binding ChangeCommand}"
+                        IsVisible="{Binding IsLoading, Converter={StaticResource NegateBooleanConverter}}"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        Text="{extensions:Translate ChangePasswordPageChange}" />
+                    <ActivityIndicator
+                        Margin="0,20,0,0"
+                        IsRunning="{Binding IsLoading}"
+                        IsVisible="{Binding IsLoading}" />
+                </StackLayout>
+            </Grid>
+        </ScrollView>
+    </controls:BaseContentPage.Content>
+</controls:BaseContentPage>

--- a/Sparky.TrakApp/Views/Settings/ChangePasswordPage.xaml.cs
+++ b/Sparky.TrakApp/Views/Settings/ChangePasswordPage.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+
+namespace Sparky.TrakApp.Views.Settings
+{
+    public partial class ChangePasswordPage
+    {
+        public ChangePasswordPage()
+        {
+            InitializeComponent();
+            BackgroundImageSource = ImageSource.FromFile("background.png");
+        }
+    }
+}

--- a/Sparky.TrakApp/Views/Settings/RequestChangePasswordPage.xaml
+++ b/Sparky.TrakApp/Views/Settings/RequestChangePasswordPage.xaml
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:BaseContentPage
+    x:Class="Sparky.TrakApp.Views.Settings.RequestChangePasswordPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Sparky.TrakApp.Controls;assembly=Sparky.TrakApp"
+    xmlns:extensions="clr-namespace:Sparky.TrakApp.Extensions;assembly=Sparky.TrakApp"
+    xmlns:settings="clr-namespace:Sparky.TrakApp.ViewModel.Settings;assembly=Sparky.TrakApp.ViewModel"
+    Title="{extensions:Translate RequestChangePasswordPageTitle}"
+    x:DataType="settings:RequestChangePasswordViewModel">
+    <controls:BaseContentPage.Content>
+        <Grid Padding="35">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+
+            <!--  App logo  -->
+            <Image
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,75,0,10"
+                Source="logo.png" />
+
+            <!--  Subtitle  -->
+            <ScrollView
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,-20,0,0"
+                HorizontalOptions="Fill"
+                HorizontalScrollBarVisibility="Never"
+                Orientation="Horizontal"
+                VerticalOptions="Start"
+                VerticalScrollBarVisibility="Never">
+                <Label Style="{StaticResource SubtitleLabelStyle}" Text="{extensions:Translate Subtitle}" />
+            </ScrollView>
+
+            <!--  Reset instructions  -->
+            <Label
+                Grid.Row="2"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,10,0,0"
+                Text="{extensions:Translate RequestChangePasswordPageInstructions}"
+                TextColor="{StaticResource TrakGrey}" />
+
+            <!--  Send button and activity indicator.  -->
+            <Button
+                Grid.Row="3"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,20,0,0"
+                AutomationId="RequestChangePasswordPageSendButton"
+                Command="{Binding SendCommand}"
+                IsVisible="{Binding IsLoading, Converter={StaticResource NegateBooleanConverter}}"
+                Style="{StaticResource PrimaryButtonStyle}"
+                Text="{extensions:Translate RequestChangePasswordPageSend}" />
+            <ActivityIndicator
+                Grid.Row="3"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,20,0,0"
+                IsRunning="{Binding IsLoading}"
+                IsVisible="{Binding IsLoading}" />
+
+            <!--  Display error messages if anything went wrong.  -->
+            <Label
+                Grid.Row="4"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,5"
+                IsEnabled="{Binding IsError}"
+                IsVisible="{Binding IsError}"
+                Style="{StaticResource ValidationLabelStyle}"
+                Text="{Binding ErrorMessage}" />
+
+            <!--  Already have a token label  -->
+            <Label
+                Grid.Row="5"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,5"
+                FontSize="Small"
+                HorizontalOptions="Center">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="{extensions:Translate RequestChangePasswordPageAlreadyHaveToken}" />
+                        <Span Text=" " />
+                        <Span FontAttributes="Bold" Text="{extensions:Translate RequestChangePasswordPageTapHere}">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding ChangePasswordCommand}" NumberOfTapsRequired="1" />
+                            </Span.GestureRecognizers>
+                        </Span>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+
+        </Grid>
+    </controls:BaseContentPage.Content>
+</controls:BaseContentPage>

--- a/Sparky.TrakApp/Views/Settings/RequestChangePasswordPage.xaml.cs
+++ b/Sparky.TrakApp/Views/Settings/RequestChangePasswordPage.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+
+namespace Sparky.TrakApp.Views.Settings
+{
+    public partial class RequestChangePasswordPage
+    {
+        public RequestChangePasswordPage()
+        {
+            InitializeComponent();
+            BackgroundImageSource = ImageSource.FromFile("background.png");
+        }
+    }
+}

--- a/Sparky.TrakApp/Views/Settings/SettingsPage.xaml
+++ b/Sparky.TrakApp/Views/Settings/SettingsPage.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:BaseContentPage
+    x:Class="Sparky.TrakApp.Views.Settings.SettingsPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Sparky.TrakApp.Controls;assembly=Sparky.TrakApp"
+    xmlns:extensions="clr-namespace:Sparky.TrakApp.Extensions;assembly=Sparky.TrakApp"
+    xmlns:settings="clr-namespace:Sparky.TrakApp.ViewModel.Settings;assembly=Sparky.TrakApp.ViewModel"
+    Title="{extensions:Translate SettingsPageTitle}"
+    x:DataType="settings:SettingsViewModel">
+    <controls:BaseContentPage.Content>
+        <TableView Intent="Settings">
+            <TableRoot>
+                <TableSection Title="{extensions:Translate SettingsPageAccountSubtitle}">
+                    <ViewCell>
+                        <Label
+                            Padding="10,0"
+                            Text="{extensions:Translate SettingsPageChangePassword}"
+                            VerticalTextAlignment="Center">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding ChangePasswordCommand}" NumberOfTapsRequired="1" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </ViewCell>
+                </TableSection>
+            </TableRoot>
+        </TableView>
+    </controls:BaseContentPage.Content>
+</controls:BaseContentPage>

--- a/Sparky.TrakApp/Views/Settings/SettingsPage.xaml.cs
+++ b/Sparky.TrakApp/Views/Settings/SettingsPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Sparky.TrakApp.Views.Settings
+{
+    public partial class SettingsPage
+    {
+        public SettingsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
- Added three new view models, one for settings and two requesting and resetting a password.
- Added unit tests for the new models.
- New views added, a basic table-based settings page now exists, with the only option currently being to allow the user to reset their password.
- Added a validator to ensure the information being provided to the change password page is valid.
- Added new authentication services to requesting a change password email and actually changing the email.