### PR TITLE
APP-26: Add new game user entry filter page and results page.

### DIFF
--- a/SparkyStudios.TrakLibrary.Model/Games/GameFilter.cs
+++ b/SparkyStudios.TrakLibrary.Model/Games/GameFilter.cs
@@ -1,0 +1,9 @@
+﻿namespace SparkyStudios.TrakLibrary.Model.Games
+{
+    public class GameFilter
+    {
+        public string Name { get; set; }
+        
+        public long Id { get; set; }
+    }
+}

--- a/SparkyStudios.TrakLibrary.Model/Games/GameUserEntryFilters.cs
+++ b/SparkyStudios.TrakLibrary.Model/Games/GameUserEntryFilters.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using SparkyStudios.TrakLibrary.Model.Response;
+
+namespace SparkyStudios.TrakLibrary.Model.Games
+{
+    [ExcludeFromCodeCoverage]
+    public class GameUserEntryFilters : HateoasResource
+    {
+        public IEnumerable<GameFilter> Platforms { get; set; }
+        
+        public IEnumerable<GameFilter> Genres { get; set; }
+        
+        public IEnumerable<GameMode> GameModes { get; set; }
+        
+        public IEnumerable<AgeRating> AgeRatings { get; set; }
+
+        public IEnumerable<GameUserEntryStatus> Statuses { get; set; }
+    }
+}

--- a/SparkyStudios.TrakLibrary.Service/Impl/RestServiceHttpClientImpl.cs
+++ b/SparkyStudios.TrakLibrary.Service/Impl/RestServiceHttpClientImpl.cs
@@ -27,7 +27,10 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
             {
                 PreserveReferencesHandling = PreserveReferencesHandling.Objects,
                 TypeNameHandling = TypeNameHandling.Objects,
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new SnakeCaseNamingStrategy()
+                }
             };
             // Deserialization settings.
             _deserializerSettings = new JsonSerializerSettings
@@ -35,12 +38,26 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
                 PreserveReferencesHandling = PreserveReferencesHandling.Objects,
                 TypeNameHandling = TypeNameHandling.Objects,
                 MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
-                DateParseHandling = DateParseHandling.None
+                DateParseHandling = DateParseHandling.None,
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new SnakeCaseNamingStrategy()
+                }
             };
         }
 
         public async Task<T> GetAsync<T>(string url)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+            
             using var client = _httpClientFactory.CreateClient("Trak");
             client.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/vnd.traklibrary.v1+json"));
@@ -75,6 +92,16 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
 
         public async Task<T> PostAsync<T, TRequest>(string url, TRequest requestBody)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+            
             // Create the client to send the requests to.
             using var client = _httpClientFactory.CreateClient("Trak");
             client.DefaultRequestHeaders.Accept.Add(
@@ -118,6 +145,16 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
 
         public async Task<T> PutAsync<T, TRequest>(string url, TRequest requestBody)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+            
             // Create the client to send the requests to.
             using var client = _httpClientFactory.CreateClient("Trak");
             client.DefaultRequestHeaders.Accept.Add(
@@ -156,6 +193,16 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
 
         public async Task<T> PatchAsync<T>(string url, IDictionary<string, object> values)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+            
             // Create the client to send the requests to.
             using var client = _httpClientFactory.CreateClient("Trak");
             client.DefaultRequestHeaders.Accept.Add(
@@ -194,6 +241,16 @@ namespace SparkyStudios.TrakLibrary.Service.Impl
 
         public async Task DeleteAsync(string url)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+            
             // Create the client to send the requests to.
             using var client = _httpClientFactory.CreateClient("Trak");
             client.DefaultRequestHeaders.Accept.Add(

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/BaseFlyoutViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/BaseFlyoutViewModelTest.cs
@@ -34,7 +34,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test
         public void LoadHomeCommand_WithNoData_DoesntThrowException()
         {
             // Arrange
-            _navigationService.Setup(mock => mock.NavigateAsync("BaseNavigationPage/HomePage"))
+            _navigationService.Setup(mock => mock.NavigateAsync("NavigationPage/HomePage"))
                 .Verifiable();
 
             // Act
@@ -49,7 +49,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test
         public void LoadGamesCommand_WithNoData_DoesntThrowException()
         {
             // Arrange
-            _navigationService.Setup(mock => mock.NavigateAsync("BaseNavigationPage/GameUserEntriesTabbedPage"))
+            _navigationService.Setup(mock => mock.NavigateAsync("NavigationPage/GameUserEntriesTabbedPage"))
                 .Verifiable();
 
             // Act
@@ -64,7 +64,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test
         public void LoadSettingsCommand_WithNoData_DoesntThrowException()
         {
             // Arrange
-            _navigationService.Setup(mock => mock.NavigateAsync("BaseNavigationPage/SettingsPage"))
+            _navigationService.Setup(mock => mock.NavigateAsync("NavigationPage/SettingsPage"))
                 .Verifiable();
 
             // Act

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameUserEntryListViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameUserEntryListViewModelTest.cs
@@ -24,7 +24,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
         private Mock<IRestService> _restService;
         private TestScheduler _scheduler;
 
-        private GameUserEntryListViewModel _gameUserEntryListViewModel;
+        private GameUserEntryTabbedListViewModel _gameUserEntryListViewModel;
 
         [SetUp]
         public void SetUp()

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameUserEntryTabbedListViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameUserEntryTabbedListViewModelTest.cs
@@ -246,7 +246,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
         [Test]
         public void AddCommand_WithNoData_DoesntThrowException()
         {
-            _navigationService.Setup(mock => mock.NavigateAsync(It.IsAny<string>(), It.IsAny<INavigationParameters>()))
+            _navigationService.Setup(mock => mock.NavigateAsync(It.IsAny<string>()))
                 .Verifiable();
             
             Assert.DoesNotThrow(() =>

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameViewModelTest.cs
@@ -160,7 +160,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
                         Links = new Dictionary<string, HateoasLink>
                         {
                             {
-                                "gameDetails", new HateoasLink
+                                "game_details", new HateoasLink
                                 {
                                     Href = new Uri("https://traklibrary.com")
                                 }
@@ -292,7 +292,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
                         Links = new Dictionary<string, HateoasLink>
                         {
                             {
-                                "gameDetails", new HateoasLink
+                                "game_details", new HateoasLink
                                 {
                                     Href = new Uri("https://traklibrary.com")
                                 }

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/HomeViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/HomeViewModelTest.cs
@@ -36,7 +36,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test
 
             // Assert
             _navigationService.Verify(
-                n => n.NavigateAsync("GameUserEntriesTabbedPage", It.IsAny<NavigationParameters>()), Times.Once);
+                n => n.NavigateAsync("GameUserEntriesTabbedPage"), Times.Once);
         }
     }
 }

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Settings/RequestChangePasswordViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Settings/RequestChangePasswordViewModelTest.cs
@@ -101,14 +101,14 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Settings
                 "vm.IsError should be false if login was successful.");
 
             _authService.Verify();
-            _navigationService.Verify(m => m.NavigateAsync("ChangePasswordPage", It.IsAny<INavigationParameters>()),
+            _navigationService.Verify(m => m.NavigateAsync("ChangePasswordPage"),
                 Times.Once);
         }
         
         [Test]
         public void ChangePasswordCommand_WithNoData_DoesntThrowException()
         {
-            _navigationService.Setup(mock => mock.NavigateAsync("ChangePasswordPage", It.IsAny<INavigationParameters>()))
+            _navigationService.Setup(mock => mock.NavigateAsync("ChangePasswordPage"))
                 .Verifiable();
             
             Assert.DoesNotThrow(() =>

--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Settings/SettingsViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Settings/SettingsViewModelTest.cs
@@ -30,7 +30,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Settings
         [Test]
         public void ChangePasswordCommand_WithNoData_DoesntThrowException()
         {
-            _navigationService.Setup(mock => mock.NavigateAsync("RequestChangePasswordPage", It.IsAny<INavigationParameters>()))
+            _navigationService.Setup(mock => mock.NavigateAsync("RequestChangePasswordPage"))
                 .Verifiable();
             
             Assert.DoesNotThrow(() =>
@@ -47,7 +47,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Settings
         [Test]
         public void ChangeEmailAddressCommand_WithNoData_DoesntThrowException()
         {
-            _navigationService.Setup(mock => mock.NavigateAsync("ChangeEmailAddressPage", It.IsAny<INavigationParameters>()))
+            _navigationService.Setup(mock => mock.NavigateAsync("ChangeEmailAddressPage"))
                 .Verifiable();
             
             Assert.DoesNotThrow(() =>
@@ -64,7 +64,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Settings
         [Test]
         public void DeleteAccountCommand_WithNoData_DoesntThrowException()
         {
-            _navigationService.Setup(mock => mock.NavigateAsync("DeleteAccountPage", It.IsAny<INavigationParameters>()))
+            _navigationService.Setup(mock => mock.NavigateAsync("DeleteAccountPage"))
                 .Verifiable();
             
             Assert.DoesNotThrow(() =>

--- a/SparkyStudios.TrakLibrary.ViewModel/Common/ReactiveViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Common/ReactiveViewModel.cs
@@ -25,6 +25,9 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Common
 
         public bool IsLoading { [ObservableAsProperty] get; }
         
+        [Reactive]
+        public bool HasLoaded { get; set; }
+        
         public virtual void Initialize(INavigationParameters parameters)
         {
             

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameBarcodeScannerViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameBarcodeScannerViewModel.cs
@@ -7,7 +7,6 @@ using Acr.UserDialogs;
 using Microsoft.AppCenter.Crashes;
 using Prism.Commands;
 using Prism.Navigation;
-using SparkyStudios.TrakLibrary.Common;
 using SparkyStudios.TrakLibrary.Model.Games;
 using SparkyStudios.TrakLibrary.Service;
 using SparkyStudios.TrakLibrary.Service.Exception;
@@ -135,7 +134,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
             // given barcode.
             var parameters = new NavigationParameters
             {
-                {"game-url", gameBarcode.GetLink("gameDetails")}
+                {"game-url", gameBarcode.GetLink("game_details")}
             };
 
             _formsDevice.BeginInvokeOnMainThread(async () =>

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameOptionsViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameOptionsViewModel.cs
@@ -161,12 +161,6 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         public Uri GameUrl { get; set; }
 
         /// <summary>
-        /// A <see cref="bool"/> that specifies whether the page has been fully loaded.
-        /// </summary>
-        [Reactive]
-        public bool HasLoaded { get; set; }
-
-        /// <summary>
         /// A <see cref="bool"/> that specifies whether any game user entries are currently being made.
         /// </summary>
         public bool IsExecutingLibraryRequest { [ObservableAsProperty] get; }

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryBacklogListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryBacklogListViewModel.cs
@@ -10,7 +10,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
     /// The <see cref="GameUserEntryBacklogListViewModel"/> is the view model that is associated with a backlog game user entry
     /// list page view. Its responsibility is to display the users personal collection of games within the backlog status.
     /// </summary>
-    public class GameUserEntryBacklogListViewModel : GameUserEntryListViewModel
+    public class GameUserEntryBacklogListViewModel : GameUserEntryTabbedListViewModel
     {
         /// <summary>
         /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryCompletedListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryCompletedListViewModel.cs
@@ -12,7 +12,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
     /// list page view. Its responsibility is to display the users personal collection of games within the completed status.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GameUserEntryCompletedListViewModel : GameUserEntryListViewModel
+    public class GameUserEntryCompletedListViewModel : GameUserEntryTabbedListViewModel
     {
         /// <summary>
         /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryDroppedListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryDroppedListViewModel.cs
@@ -12,7 +12,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
     /// list page view. Its responsibility is to display the users personal collection of games within the dropped status.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GameUserEntryDroppedListViewModel : GameUserEntryListViewModel
+    public class GameUserEntryDroppedListViewModel : GameUserEntryTabbedListViewModel
     {
         /// <summary>
         /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryFilterViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryFilterViewModel.cs
@@ -1,0 +1,361 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AppCenter.Crashes;
+using Prism.Navigation;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using SparkyStudios.TrakLibrary.Common.Extensions;
+using SparkyStudios.TrakLibrary.Model.Games;
+using SparkyStudios.TrakLibrary.Service;
+using SparkyStudios.TrakLibrary.Service.Exception;
+using SparkyStudios.TrakLibrary.ViewModel.Common;
+
+namespace SparkyStudios.TrakLibrary.ViewModel.Games
+{
+    public class GameUserEntryFilterViewModel : ReactiveViewModel
+    {
+        private readonly IRestService _restService;
+        
+        public GameUserEntryFilterViewModel(IScheduler scheduler, INavigationService navigationService, IRestService restService) : base(scheduler, navigationService)
+        {
+            _restService = restService;
+            
+            LoadGameFiltersCommand = ReactiveCommand.CreateFromTask(LoadGameFiltersAsync, outputScheduler: scheduler);
+            // Report errors if an exception was thrown.
+            LoadGameFiltersCommand.ThrownExceptions.Subscribe(ex =>
+            {
+                IsError = true;
+                if (!(ex is ApiException))
+                {
+                    Crashes.TrackError(ex);
+                }
+            });
+            
+            PlatformGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
+            {
+                IsPlatformGroupExpanded = !IsPlatformGroupExpanded;
+            });
+            GenreGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
+            {
+                IsGenreGroupExpanded = !IsGenreGroupExpanded;
+            });
+            GameModeGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
+            {
+                IsGameModeGroupExpanded = !IsGameModeGroupExpanded;
+            });
+            AgeRatingGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
+            {
+                IsAgeRatingGroupExpanded = !IsAgeRatingGroupExpanded;
+            });
+            StatusGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
+            {
+                IsStatusGroupExpanded = !IsStatusGroupExpanded;
+            });
+            
+            PlatformTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
+            {
+                if (item == null) return;
+                
+                var index = Platforms.IndexOf(item);
+                    
+                item.IsSelected = !item.IsSelected;
+                Platforms[index] = item;
+            });
+            
+            GenreTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
+            {
+                if (item == null) return;
+                
+                var index = Genres.IndexOf(item);
+                    
+                item.IsSelected = !item.IsSelected;
+                Genres[index] = item;
+            });
+            
+            GameModeTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
+            {
+                if (item == null) return;
+                
+                var index = GameModes.IndexOf(item);
+                    
+                item.IsSelected = !item.IsSelected;
+                GameModes[index] = item;
+            });
+            
+            AgeRatingTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
+            {
+                if (item == null) return;
+                
+                var index = AgeRatings.IndexOf(item);
+                    
+                item.IsSelected = !item.IsSelected;
+                AgeRatings[index] = item;
+            });
+            
+            StatusTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
+            {
+                if (item == null) return;
+                
+                var index = Statuses.IndexOf(item);
+                    
+                item.IsSelected = !item.IsSelected;
+                Statuses[index] = item;
+            });
+            
+            ApplyCommand = ReactiveCommand.CreateFromTask(ApplyAsync, outputScheduler: scheduler);
+
+            this.WhenAnyObservable(x => x.LoadGameFiltersCommand.IsExecuting)
+                .ToPropertyEx(this, x => x.IsLoading, scheduler: scheduler);
+        }
+        
+        /// <summary>
+        /// A <see cref="bool"/> that specifies whether the platform filters have been expanded on the view.
+        /// </summary>
+        [Reactive]
+        public bool IsPlatformGroupExpanded { get; set; }
+        
+        /// <summary>
+        /// A <see cref="bool"/> that specifies whether the genre filters have been expanded on the view.
+        /// </summary>
+        [Reactive]
+        public bool IsGenreGroupExpanded { get; set; }
+        
+        /// <summary>
+        /// A <see cref="bool"/> that specifies whether the game mode filters have been expanded on the view.
+        /// </summary>
+        [Reactive]
+        public bool IsGameModeGroupExpanded { get; set; }
+        
+        /// <summary>
+        /// A <see cref="bool"/> that specifies whether the age rating filters have been expanded on the view.
+        /// </summary>
+        [Reactive]
+        public bool IsAgeRatingGroupExpanded { get; set; }
+
+        /// <summary>
+        /// A <see cref="bool"/> that specifies whether the statuses filters have been expanded on the view.
+        /// </summary>
+        [Reactive]
+        public bool IsStatusGroupExpanded { get; set; }
+
+        /// <summary>
+        /// A <see cref="ObservableCollection{T}" /> that contains all the selectable platform filters.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<ItemEntryViewModel> Platforms { get; set; }
+        
+        /// <summary>
+        /// A <see cref="ObservableCollection{T}" /> that contains all the selectable genre filters.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<ItemEntryViewModel> Genres { get; set; }
+        
+        /// <summary>
+        /// A <see cref="ObservableCollection{T}" /> that contains all the selectable game mode filters.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<ItemEntryViewModel> GameModes { get; set; }
+        
+        /// <summary>
+        /// A <see cref="ObservableCollection{T}" /> that contains all the selectable age rating filters.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<ItemEntryViewModel> AgeRatings { get; set; }
+
+        /// <summary>
+        /// A <see cref="ObservableCollection{T}" /> that contains all the selectable status filters.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<ItemEntryViewModel> Statuses { get; set; }
+
+        /// <summary>
+        /// Command that is invoked each time the page is first navigated to. When called, the command will
+        /// propagate the request and call the <see cref="LoadGameFiltersAsync"/> method.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> LoadGameFiltersCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked each time the user taps the "Platform" group header on the view. When called,
+        /// the command switch the <see cref="IsPlatformGroupExpanded"/> state.
+        /// </summary>
+        public ReactiveCommand<bool, Unit> PlatformGroupTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked each time the user taps the "Genre" group header on the view. When called,
+        /// the command switch the <see cref="IsGenreGroupExpanded"/> state.
+        /// </summary>
+        public ReactiveCommand<bool, Unit> GenreGroupTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked each time the user taps the "Game mode" group header on the view. When called,
+        /// the command switch the <see cref="IsGameModeGroupExpanded"/> state.
+        /// </summary>
+        public ReactiveCommand<bool, Unit> GameModeGroupTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked each time the user taps the "Age rating" group header on the view. When called,
+        /// the command switch the <see cref="IsAgeRatingGroupExpanded"/> state.
+        /// </summary>
+        public ReactiveCommand<bool, Unit> AgeRatingGroupTappedCommand { get; }
+
+        /// <summary>
+        /// Command that is invoked each time the user taps the "Age rating" group header on the view. When called,
+        /// the command switch the <see cref="IsStatusGroupExpanded"/> state.
+        /// </summary>
+        public ReactiveCommand<bool, Unit> StatusGroupTappedCommand { get; }
+
+        /// <summary>
+        /// Command that is invoked any of the items within the "Platforms" group is tapped. When tapped, it will
+        /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
+        /// view with the new information.
+        /// </summary>
+        public ReactiveCommand<ItemEntryViewModel, Unit> PlatformTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked any of the items within the "Genre" group is tapped. When tapped, it will
+        /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
+        /// view with the new information.
+        /// </summary>
+        public ReactiveCommand<ItemEntryViewModel, Unit> GenreTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked any of the items within the "Game mode" group is tapped. When tapped, it will
+        /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
+        /// view with the new information.
+        /// </summary>
+        public ReactiveCommand<ItemEntryViewModel, Unit> GameModeTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked any of the items within the "Age rating" group is tapped. When tapped, it will
+        /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
+        /// view with the new information.
+        /// </summary>
+        public ReactiveCommand<ItemEntryViewModel, Unit> AgeRatingTappedCommand { get; }
+        
+        /// <summary>
+        /// Command that is invoked any of the items within the "Status" group is tapped. When tapped, it will
+        /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
+        /// view with the new information.
+        /// </summary>
+        public ReactiveCommand<ItemEntryViewModel, Unit> StatusTappedCommand { get; }
+        
+        public ReactiveCommand<Unit, Unit> ApplyCommand { get; }
+        
+        /// <summary>
+        /// Overriden method that is automatically invoked when the page is navigated to. Its purpose is to retrieve
+        /// values from the <see cref="NavigationParameters" /> before invoking the <see cref="LoadGameFiltersCommand" />
+        /// command to load and display the game filter information on the view.
+        /// </summary>
+        /// <param name="parameters">The <see cref="NavigationParameters" />, which contains information for display purposes.</param>
+        public override void OnNavigatedTo(INavigationParameters parameters)
+        {
+            if (parameters.GetNavigationMode() == NavigationMode.New)
+            {
+                // Load the game filters immediately on navigation.
+                LoadGameFiltersCommand.Execute().Subscribe();
+            }
+        }
+        
+         /// <summary>
+        /// Private method that is invoked by the <see cref="LoadGameFiltersCommand" /> when activated by the associated
+        /// view. This method will attempt to retrieve the game filter from the url provided by the
+        /// <see cref="NavigationParameters" /> and populate all of the information within this view model with data
+        /// from the returned <see cref="GameUserEntryFilters" />. If any errors occur during the API requests, the exceptions
+        /// are caught and the errors the IsError boolean to true.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> which specifies whether the asynchronous task completed successfully.</returns>
+        private async Task LoadGameFiltersAsync()
+        {
+            // Remove any previous error messages before loading.
+            IsError = false;
+            HasLoaded = false;
+ 
+            // Retrieve the game and set some game information on the view.
+            var gameUserEntryFilters = await _restService.GetAsync<GameUserEntryFilters>("games/entries/filters");
+            
+            // Convert the platform filters into a selectable list.
+            Platforms = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Platforms.Select(p => new ItemEntryViewModel
+            {
+                Id = p.Id,
+                Name = p.Name
+            }).ToList());
+            
+            // Convert the genre filters into a selectable list.
+            Genres = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Genres.Select(p => new ItemEntryViewModel
+            {
+                Id = p.Id,
+                Name = p.Name
+            }).ToList());
+            
+            // Convert the game mode filters into a selectable list.
+            GameModes = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.GameModes.Select(p => new ItemEntryViewModel
+            {
+                Id = (int)p,
+                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+            }).ToList());
+            
+            // Convert the age rating filters into a selectable list.
+            AgeRatings = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.AgeRatings.Select(p => new ItemEntryViewModel
+            {
+                Id = (int)p,
+                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+            }).ToList());
+
+            // Convert the age rating filters into a selectable list.
+            Statuses = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Statuses.Select(p => new ItemEntryViewModel
+            {
+                Id = (int)p,
+                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+            }).ToList());
+
+            HasLoaded = true;
+        }
+         
+         /// <summary>
+         /// Private method that is invoked by the <see cref="ApplyCommand"/>. When invoked, it will navigate the user
+         /// to a game user list page filtered by the parameters specified within this view model.
+         /// </summary>
+         /// <returns></returns>
+         private async Task ApplyAsync()
+         {
+             var platformIds = Platforms.Where(p => p.IsSelected)
+                 .Select(p => p.Id)
+                 .ToList();
+             
+             var genreIds = Genres.Where(g => g.IsSelected)
+                 .Select(g => g.Id)
+                 .ToList();
+
+             var gameModes = GameModes.Where(g => g.IsSelected)
+                 .Select(g => ((GameMode)g.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                 .ToList();
+
+             var ageRatings = AgeRatings.Where(a => a.IsSelected)
+                 .Select(a => ((AgeRating) a.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                 .ToList();
+             
+             var statuses = Statuses.Where(s => s.IsSelected)
+                 .Select(s => ((GameUserEntryStatus) s.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                 .ToList();
+             
+             var url = "games/entries/search" + 
+                       "?platform-ids" + (platformIds.Count > 0 ? $"={string.Join(",", platformIds)}" : string.Empty) +
+                       "&genre-ids" + (genreIds.Count > 0 ? $"={string.Join(",", genreIds)}" : string.Empty) +
+                       "&game-modes" + (gameModes.Count > 0 ? $"={string.Join(",", gameModes)}" : string.Empty) +
+                       "&age-ratings" + (ageRatings.Count > 0 ? $"={string.Join(",", ageRatings)}" : string.Empty) +
+                       "&statuses" + (statuses.Count > 0 ? $"={string.Join(",", statuses)}" : string.Empty);
+             
+             var result = await NavigationService.NavigateAsync("GameUserEntryListPage", new NavigationParameters
+             {
+                 { "base-url", url }
+             });
+         }
+    }
+}

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryFilterViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryFilterViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -19,14 +18,28 @@ using SparkyStudios.TrakLibrary.ViewModel.Common;
 
 namespace SparkyStudios.TrakLibrary.ViewModel.Games
 {
+    /// <summary>
+    /// The <see cref="GameUserEntryFilterViewModel" /> is a simple view model that is associated with the game user entry
+    /// filter page view. Its responsibility is to display all the filterable types for all of the game user entries and
+    /// to apply these filter results to a new game user entry page.
+    /// </summary>
     public class GameUserEntryFilterViewModel : ReactiveViewModel
     {
         private readonly IRestService _restService;
-        
-        public GameUserEntryFilterViewModel(IScheduler scheduler, INavigationService navigationService, IRestService restService) : base(scheduler, navigationService)
+
+        /// <summary>
+        /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.
+        /// The constructors should never be invoked outside of the Prism DI framework. All instantiation
+        /// should be handled by the framework.
+        /// </summary>
+        /// <param name="scheduler">The <see cref="IScheduler" /> instance to inject.</param>
+        /// <param name="navigationService">The <see cref="INavigationService" /> instance to inject.</param>
+        /// <param name="restService">The <see cref="IRestService" /> instance to inject.</param>
+        public GameUserEntryFilterViewModel(IScheduler scheduler, INavigationService navigationService,
+            IRestService restService) : base(scheduler, navigationService)
         {
             _restService = restService;
-            
+
             LoadGameFiltersCommand = ReactiveCommand.CreateFromTask(LoadGameFiltersAsync, outputScheduler: scheduler);
             // Report errors if an exception was thrown.
             LoadGameFiltersCommand.ThrownExceptions.Subscribe(ex =>
@@ -37,7 +50,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
                     Crashes.TrackError(ex);
                 }
             });
-            
+
             PlatformGroupTappedCommand = ReactiveCommand.Create<bool>(b =>
             {
                 IsPlatformGroupExpanded = !IsPlatformGroupExpanded;
@@ -58,81 +71,81 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
             {
                 IsStatusGroupExpanded = !IsStatusGroupExpanded;
             });
-            
+
             PlatformTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
             {
                 if (item == null) return;
-                
+
                 var index = Platforms.IndexOf(item);
-                    
+
                 item.IsSelected = !item.IsSelected;
                 Platforms[index] = item;
             });
-            
+
             GenreTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
             {
                 if (item == null) return;
-                
+
                 var index = Genres.IndexOf(item);
-                    
+
                 item.IsSelected = !item.IsSelected;
                 Genres[index] = item;
             });
-            
+
             GameModeTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
             {
                 if (item == null) return;
-                
+
                 var index = GameModes.IndexOf(item);
-                    
+
                 item.IsSelected = !item.IsSelected;
                 GameModes[index] = item;
             });
-            
+
             AgeRatingTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
             {
                 if (item == null) return;
-                
+
                 var index = AgeRatings.IndexOf(item);
-                    
+
                 item.IsSelected = !item.IsSelected;
                 AgeRatings[index] = item;
             });
-            
+
             StatusTappedCommand = ReactiveCommand.Create<ItemEntryViewModel>(item =>
             {
                 if (item == null) return;
-                
+
                 var index = Statuses.IndexOf(item);
-                    
+
                 item.IsSelected = !item.IsSelected;
                 Statuses[index] = item;
             });
-            
+
             ApplyCommand = ReactiveCommand.CreateFromTask(ApplyAsync, outputScheduler: scheduler);
 
             this.WhenAnyObservable(x => x.LoadGameFiltersCommand.IsExecuting)
                 .ToPropertyEx(this, x => x.IsLoading, scheduler: scheduler);
         }
-        
+
         /// <summary>
         /// A <see cref="bool"/> that specifies whether the platform filters have been expanded on the view.
         /// </summary>
         [Reactive]
         public bool IsPlatformGroupExpanded { get; set; }
-        
+
         /// <summary>
         /// A <see cref="bool"/> that specifies whether the genre filters have been expanded on the view.
         /// </summary>
         [Reactive]
         public bool IsGenreGroupExpanded { get; set; }
-        
+
         /// <summary>
         /// A <see cref="bool"/> that specifies whether the game mode filters have been expanded on the view.
         /// </summary>
         [Reactive]
         public bool IsGameModeGroupExpanded { get; set; }
-        
+
         /// <summary>
         /// A <see cref="bool"/> that specifies whether the age rating filters have been expanded on the view.
         /// </summary>
@@ -150,19 +163,19 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         /// </summary>
         [Reactive]
         public ObservableCollection<ItemEntryViewModel> Platforms { get; set; }
-        
+
         /// <summary>
         /// A <see cref="ObservableCollection{T}" /> that contains all the selectable genre filters.
         /// </summary>
         [Reactive]
         public ObservableCollection<ItemEntryViewModel> Genres { get; set; }
-        
+
         /// <summary>
         /// A <see cref="ObservableCollection{T}" /> that contains all the selectable game mode filters.
         /// </summary>
         [Reactive]
         public ObservableCollection<ItemEntryViewModel> GameModes { get; set; }
-        
+
         /// <summary>
         /// A <see cref="ObservableCollection{T}" /> that contains all the selectable age rating filters.
         /// </summary>
@@ -180,25 +193,25 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         /// propagate the request and call the <see cref="LoadGameFiltersAsync"/> method.
         /// </summary>
         public ReactiveCommand<Unit, Unit> LoadGameFiltersCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked each time the user taps the "Platform" group header on the view. When called,
         /// the command switch the <see cref="IsPlatformGroupExpanded"/> state.
         /// </summary>
         public ReactiveCommand<bool, Unit> PlatformGroupTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked each time the user taps the "Genre" group header on the view. When called,
         /// the command switch the <see cref="IsGenreGroupExpanded"/> state.
         /// </summary>
         public ReactiveCommand<bool, Unit> GenreGroupTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked each time the user taps the "Game mode" group header on the view. When called,
         /// the command switch the <see cref="IsGameModeGroupExpanded"/> state.
         /// </summary>
         public ReactiveCommand<bool, Unit> GameModeGroupTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked each time the user taps the "Age rating" group header on the view. When called,
         /// the command switch the <see cref="IsAgeRatingGroupExpanded"/> state.
@@ -217,37 +230,41 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         /// view with the new information.
         /// </summary>
         public ReactiveCommand<ItemEntryViewModel, Unit> PlatformTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked any of the items within the "Genre" group is tapped. When tapped, it will
         /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
         /// view with the new information.
         /// </summary>
         public ReactiveCommand<ItemEntryViewModel, Unit> GenreTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked any of the items within the "Game mode" group is tapped. When tapped, it will
         /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
         /// view with the new information.
         /// </summary>
         public ReactiveCommand<ItemEntryViewModel, Unit> GameModeTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked any of the items within the "Age rating" group is tapped. When tapped, it will
         /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
         /// view with the new information.
         /// </summary>
         public ReactiveCommand<ItemEntryViewModel, Unit> AgeRatingTappedCommand { get; }
-        
+
         /// <summary>
         /// Command that is invoked any of the items within the "Status" group is tapped. When tapped, it will
         /// store the state of the current checked status in the <see cref="ItemEntryViewModel"/> and update the
         /// view with the new information.
         /// </summary>
         public ReactiveCommand<ItemEntryViewModel, Unit> StatusTappedCommand { get; }
-        
+
+        /// <summary>
+        /// Command that is invoked each time the apply filter button is tapped by the user on the view.
+        /// When called, the command will propagate the request and call the <see cref="ApplyAsync"/> method.
+        /// </summary>
         public ReactiveCommand<Unit, Unit> ApplyCommand { get; }
-        
+
         /// <summary>
         /// Overriden method that is automatically invoked when the page is navigated to. Its purpose is to retrieve
         /// values from the <see cref="NavigationParameters" /> before invoking the <see cref="LoadGameFiltersCommand" />
@@ -262,8 +279,8 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
                 LoadGameFiltersCommand.Execute().Subscribe();
             }
         }
-        
-         /// <summary>
+
+        /// <summary>
         /// Private method that is invoked by the <see cref="LoadGameFiltersCommand" /> when activated by the associated
         /// view. This method will attempt to retrieve the game filter from the url provided by the
         /// <see cref="NavigationParameters" /> and populate all of the information within this view model with data
@@ -276,86 +293,91 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
             // Remove any previous error messages before loading.
             IsError = false;
             HasLoaded = false;
- 
+
             // Retrieve the game and set some game information on the view.
             var gameUserEntryFilters = await _restService.GetAsync<GameUserEntryFilters>("games/entries/filters");
-            
+
             // Convert the platform filters into a selectable list.
-            Platforms = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Platforms.Select(p => new ItemEntryViewModel
-            {
-                Id = p.Id,
-                Name = p.Name
-            }).ToList());
-            
+            Platforms = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Platforms.Select(p =>
+                new ItemEntryViewModel
+                {
+                    Id = p.Id,
+                    Name = p.Name
+                }).ToList());
+
             // Convert the genre filters into a selectable list.
-            Genres = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Genres.Select(p => new ItemEntryViewModel
-            {
-                Id = p.Id,
-                Name = p.Name
-            }).ToList());
-            
+            Genres = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Genres.Select(p =>
+                new ItemEntryViewModel
+                {
+                    Id = p.Id,
+                    Name = p.Name
+                }).ToList());
+
             // Convert the game mode filters into a selectable list.
-            GameModes = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.GameModes.Select(p => new ItemEntryViewModel
-            {
-                Id = (int)p,
-                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
-            }).ToList());
-            
-            // Convert the age rating filters into a selectable list.
-            AgeRatings = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.AgeRatings.Select(p => new ItemEntryViewModel
-            {
-                Id = (int)p,
-                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
-            }).ToList());
+            GameModes = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.GameModes.Select(p =>
+                new ItemEntryViewModel
+                {
+                    Id = (int) p,
+                    Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+                }).ToList());
 
             // Convert the age rating filters into a selectable list.
-            Statuses = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Statuses.Select(p => new ItemEntryViewModel
-            {
-                Id = (int)p,
-                Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
-            }).ToList());
+            AgeRatings = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.AgeRatings.Select(p =>
+                new ItemEntryViewModel
+                {
+                    Id = (int) p,
+                    Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+                }).ToList());
+
+            // Convert the age rating filters into a selectable list.
+            Statuses = new ObservableCollection<ItemEntryViewModel>(gameUserEntryFilters.Statuses.Select(p =>
+                new ItemEntryViewModel
+                {
+                    Id = (int) p,
+                    Name = p.GetAttributeValue<DescriptionAttribute, string>(s => s.Description)
+                }).ToList());
 
             HasLoaded = true;
         }
-         
-         /// <summary>
-         /// Private method that is invoked by the <see cref="ApplyCommand"/>. When invoked, it will navigate the user
-         /// to a game user list page filtered by the parameters specified within this view model.
-         /// </summary>
-         /// <returns></returns>
-         private async Task ApplyAsync()
-         {
-             var platformIds = Platforms.Where(p => p.IsSelected)
-                 .Select(p => p.Id)
-                 .ToList();
-             
-             var genreIds = Genres.Where(g => g.IsSelected)
-                 .Select(g => g.Id)
-                 .ToList();
 
-             var gameModes = GameModes.Where(g => g.IsSelected)
-                 .Select(g => ((GameMode)g.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
-                 .ToList();
+        /// <summary>
+        /// Private method that is invoked by the <see cref="ApplyCommand"/>. When invoked, it will navigate the user
+        /// to a game user list page filtered by the parameters specified within this view model.
+        /// </summary>
+        /// <returns></returns>
+        private async Task ApplyAsync()
+        {
+            var platformIds = Platforms.Where(p => p.IsSelected)
+                .Select(p => p.Id)
+                .ToList();
 
-             var ageRatings = AgeRatings.Where(a => a.IsSelected)
-                 .Select(a => ((AgeRating) a.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
-                 .ToList();
-             
-             var statuses = Statuses.Where(s => s.IsSelected)
-                 .Select(s => ((GameUserEntryStatus) s.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
-                 .ToList();
-             
-             var url = "games/entries/search" + 
-                       "?platform-ids" + (platformIds.Count > 0 ? $"={string.Join(",", platformIds)}" : string.Empty) +
-                       "&genre-ids" + (genreIds.Count > 0 ? $"={string.Join(",", genreIds)}" : string.Empty) +
-                       "&game-modes" + (gameModes.Count > 0 ? $"={string.Join(",", gameModes)}" : string.Empty) +
-                       "&age-ratings" + (ageRatings.Count > 0 ? $"={string.Join(",", ageRatings)}" : string.Empty) +
-                       "&statuses" + (statuses.Count > 0 ? $"={string.Join(",", statuses)}" : string.Empty);
-             
-             var result = await NavigationService.NavigateAsync("GameUserEntryListPage", new NavigationParameters
-             {
-                 { "base-url", url }
-             });
-         }
+            var genreIds = Genres.Where(g => g.IsSelected)
+                .Select(g => g.Id)
+                .ToList();
+
+            var gameModes = GameModes.Where(g => g.IsSelected)
+                .Select(g => ((GameMode) g.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                .ToList();
+
+            var ageRatings = AgeRatings.Where(a => a.IsSelected)
+                .Select(a => ((AgeRating) a.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                .ToList();
+
+            var statuses = Statuses.Where(s => s.IsSelected)
+                .Select(s => ((GameUserEntryStatus) s.Id).GetAttributeValue<EnumMemberAttribute, string>(e => e.Value))
+                .ToList();
+
+            var url = "games/entries/search" +
+                      "?platform-ids" + (platformIds.Count > 0 ? $"={string.Join(",", platformIds)}" : string.Empty) +
+                      "&genre-ids" + (genreIds.Count > 0 ? $"={string.Join(",", genreIds)}" : string.Empty) +
+                      "&game-modes" + (gameModes.Count > 0 ? $"={string.Join(",", gameModes)}" : string.Empty) +
+                      "&age-ratings" + (ageRatings.Count > 0 ? $"={string.Join(",", ageRatings)}" : string.Empty) +
+                      "&statuses" + (statuses.Count > 0 ? $"={string.Join(",", statuses)}" : string.Empty);
+
+            await NavigationService.NavigateAsync("GameUserEntryListPage", new NavigationParameters
+            {
+                {"base-url", url}
+            });
+        }
     }
 }

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryInProgressListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryInProgressListViewModel.cs
@@ -12,7 +12,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
     /// list page view. Its responsibility is to display the users personal collection of games within the in progress status.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GameUserEntryInProgressListViewModel : GameUserEntryListViewModel
+    public class GameUserEntryInProgressListViewModel : GameUserEntryTabbedListViewModel
     {
         /// <summary>
         /// Constructor that is invoked by the Prism DI framework to inject all of the needed dependencies.

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
@@ -73,15 +73,9 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
          * the user is navigating from the game options page.
          */
         public bool ShouldReload { get; set; }
-        
-        /// <summary>
-        /// A <see cref="bool"/> that specifies whether the page has been fully loaded.
-        /// </summary>
-        [Reactive]
-        public bool HasLoaded { get; set; }
 
         /// <summary>
-        /// A <see cref="Uri"/> which specifies the URI from which the <see cref="GameDetails"/> was loaded from.
+        /// A <see cref="Uri"/> which specifies the URI from which the <see cref="game_details"/> was loaded from.
         /// </summary>
         [Reactive]
         public Uri GameUrl { get; set; }
@@ -248,7 +242,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         /// Private method that is invoked by the <see cref="LoadGameDetailsCommand" /> when activated by the associated
         /// view. This method will attempt to retrieve the game information from the url provided by the
         /// <see cref="NavigationParameters" /> and populate all of the information within this view model with data
-        /// from the returned <see cref="GameDetails" />. If any errors occur during the API requests, the exceptions
+        /// from the returned <see cref="game_details" />. If any errors occur during the API requests, the exceptions
         /// are caught and the errors the IsError boolean to true.
         /// </summary>
         /// <returns>A <see cref="Task" /> which specifies whether the asynchronous task completed successfully.</returns>
@@ -321,8 +315,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
 
             // See if there is an existing entry for this game in the users collection.
             var gameUserEntries =
-                await _restService.GetAsync<HateoasPage<GameUserEntry>>(gameDetails.GetLink("entries") +
-                                                                        $"?game-id={_gameId}&user-id={userId}");
+                await _restService.GetAsync<HateoasPage<GameUserEntry>>($"{gameDetails.GetLink("entries")}?user-id={userId}");
 
             // See if the game is already in the users collection.
             if (gameUserEntries.Embedded != null && gameUserEntries.Embedded.Data.Any())
@@ -346,7 +339,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
 
         /// <summary>
         /// Private method that is invoked within the <see cref="LoadGameDetailsAsync" /> method. Its purpose
-        /// is to convert the provided <see cref="IEnumerable{T}" /> of <see cref="GameDetails" /> instances into
+        /// is to convert the provided <see cref="IEnumerable{T}" /> of <see cref="game_details" /> instances into
         /// <see cref="ListItemViewModel" /> instances for displaying within the list on the game page view.
         /// </summary>
         /// <param name="games">The <see cref="IEnumerable{T}" /> to convert into <see cref="ListItemViewModel" /> instances.</param>

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
@@ -17,7 +17,6 @@ using SparkyStudios.TrakLibrary.Service;
 using SparkyStudios.TrakLibrary.Service.Exception;
 using SparkyStudios.TrakLibrary.ViewModel.Common;
 using SparkyStudios.TrakLibrary.ViewModel.Resources;
-using Xamarin.Forms.Internals;
 
 namespace SparkyStudios.TrakLibrary.ViewModel.Games
 {
@@ -242,7 +241,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         /// Private method that is invoked by the <see cref="LoadGameDetailsCommand" /> when activated by the associated
         /// view. This method will attempt to retrieve the game information from the url provided by the
         /// <see cref="NavigationParameters" /> and populate all of the information within this view model with data
-        /// from the returned <see cref="game_details" />. If any errors occur during the API requests, the exceptions
+        /// from the returned <see cref="GameDetails" />. If any errors occur during the API requests, the exceptions
         /// are caught and the errors the IsError boolean to true.
         /// </summary>
         /// <returns>A <see cref="Task" /> which specifies whether the asynchronous task completed successfully.</returns>

--- a/SparkyStudios.TrakLibrary.ViewModel/Login/LoadingViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Login/LoadingViewModel.cs
@@ -85,7 +85,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Login
                     }
                     else
                     {
-                        await NavigationService.NavigateAsync(new Uri("/BaseFlyoutPage/NavigationPage/HomePage", UriKind.Absolute));
+                        await NavigationService.NavigateAsync("/BaseFlyoutPage/NavigationPage/HomePage");
                     }
                 }
                 else

--- a/SparkyStudios.TrakLibrary.ViewModel/Resources/Messages.Designer.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Resources/Messages.Designer.cs
@@ -781,6 +781,15 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not rated yet:.
+        /// </summary>
+        public static string GamePageNotRatedYet {
+            get {
+                return ResourceManager.GetString("GamePageNotRatedYet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Options.
         /// </summary>
         public static string GamePageOptions {
@@ -943,6 +952,78 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Age ratings.
+        /// </summary>
+        public static string GameUserEntryFilterPageAgeRatings {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageAgeRatings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply.
+        /// </summary>
+        public static string GameUserEntryFilterPageApply {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageApply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Game modes.
+        /// </summary>
+        public static string GameUserEntryFilterPageGameModes {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageGameModes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Genres.
+        /// </summary>
+        public static string GameUserEntryFilterPageGenres {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageGenres", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Platforms.
+        /// </summary>
+        public static string GameUserEntryFilterPagePlatforms {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPagePlatforms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Statuses.
+        /// </summary>
+        public static string GameUserEntryFilterPageStatuses {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageStatuses", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter.
+        /// </summary>
+        public static string GameUserEntryFilterPageTitle {
+            get {
+                return ResourceManager.GetString("GameUserEntryFilterPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add game.
+        /// </summary>
+        public static string GameUserEntryListPageAddGame {
+            get {
+                return ResourceManager.GetString("GameUserEntryListPageAddGame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You currently have no games in .
         /// </summary>
         public static string GameUserEntryListPageEmpty {
@@ -961,11 +1042,29 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No entries match the given query..
+        /// </summary>
+        public static string GameUserEntryListPageEmptyResults {
+            get {
+                return ResourceManager.GetString("GameUserEntryListPageEmptyResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to load your games due to an error on the server..
         /// </summary>
         public static string GameUserEntryListPageEmptyServerError {
             get {
                 return ResourceManager.GetString("GameUserEntryListPageEmptyServerError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Entries.
+        /// </summary>
+        public static string GameUserEntryListPageTitle {
+            get {
+                return ResourceManager.GetString("GameUserEntryListPageTitle", resourceCulture);
             }
         }
         

--- a/SparkyStudios.TrakLibrary.ViewModel/Resources/Messages.resx
+++ b/SparkyStudios.TrakLibrary.ViewModel/Resources/Messages.resx
@@ -1,585 +1,720 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true"></xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<data name="TrakTitle" xml:space="preserve">
-		<value>Trak</value>
-	</data>
-	<data name="LoginPageLogIn" xml:space="preserve">
-		<value>Log in</value>
-	</data>
-	<data name="LoginPageUsernameOrEmail" xml:space="preserve">
-		<value>Username or Email</value>
-	</data>
-	<data name="LoginPagePassword" xml:space="preserve">
-		<value>Password</value>
-	</data>
-	<data name="LoginPageForgottenPassword" xml:space="preserve">
-		<value>Forgotten password?</value>
-	</data>
-	<data name="LoginPageDontHaveAnAccount" xml:space="preserve">
-		<value>Don't have an account? </value>
-	</data>
-	<data name="LoginPageJoinNow" xml:space="preserve">
-		<value>Join Now</value>
-	</data>
-	<data name="Subtitle" xml:space="preserve">
-		<value>Games, Books, Manga, Anime</value>
-	</data>
-	<data name="RegisterPageTitle" xml:space="preserve">
-		<value>Create Account</value>
-	</data>
-	<data name="RegisterPageUsername" xml:space="preserve">
-		<value>Username</value>
-	</data>
-	<data name="RegisterPageEmailAddress" xml:space="preserve">
-		<value>Email address</value>
-	</data>
-	<data name="RegisterPagePassword" xml:space="preserve">
-		<value>Password*</value>
-	</data>
-	<data name="RegisterPageConfirmPassword" xml:space="preserve">
-		<value>Confirm password*</value>
-	</data>
-	<data name="RegisterPageSignUp" xml:space="preserve">
-		<value>Sign up</value>
-	</data>
-	<data name="RegisterPagePrivacyPolicyAndTermsOfUse" xml:space="preserve">
-		<value>Privacy Policy &amp; Terms of Use</value>
-	</data>
-	<data name="RegisterPageLogIn" xml:space="preserve">
-		<value>Log in</value>
-	</data>
-	<data name="LoginPageTitle" xml:space="preserve">
-		<value>Log in</value>
-	</data>
-	<data name="VerificationPageTitle" xml:space="preserve">
-		<value>Verify Account</value>
-	</data>
-	<data name="VerificationPageConfirmation" xml:space="preserve">
-		<value>Thank you, we have now sent you a confirmation email with your verification code.</value>
-	</data>
-	<data name="VerificationPageVerificationCode" xml:space="preserve">
-		<value>Verification Code</value>
-	</data>
-	<data name="VerificationPageVerify" xml:space="preserve">
-		<value>Verify</value>
-	</data>
-	<data name="VerificationPageHaventReceivedEmail" xml:space="preserve">
-		<value>Haven't received an email? </value>
-	</data>
-	<data name="VerificationPageSendAgain" xml:space="preserve">
-		<value>Send again</value>
-	</data>
-	<data name="ErrorMessageIncorrectCredentials" xml:space="preserve">
-		<value>Your credentials were incorrect. Please try again.</value>
-	</data>
-	<data name="ErrorMessageApiError" xml:space="preserve">
-		<value>An error occurred making the request. Please try again.</value>
-	</data>
-	<data name="ErrorMessageGeneric" xml:space="preserve">
-		<value>An error occurred making the request.</value>
-	</data>
-	<data name="RegistrationErrorMessageUsernameEmpty" xml:space="preserve">
-		<value>Username cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RegistrationErrorMessageUsernameWhitespace" xml:space="preserve">
-		<value>Username cannot contain any spaces.</value>
-	</data>
-	<data name="RegistrationErrorMessageUsernameLength" xml:space="preserve">
-		<value>Username must be between 1 and 255 characters.</value>
-	</data>
-	<data name="RegistrationErrorMessageUsernameInvalidCharacters" xml:space="preserve">
-		<value>The username can only contain letters, numbers, under-scores and hyphens.</value>
-	</data>
-	<data name="RegistrationErrorMessageEmailAddressEmpty" xml:space="preserve">
-		<value>Email address cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RegistrationErrorMessageEmailAddressInvalid" xml:space="preserve">
-		<value>Email address is invalid.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordEmpty" xml:space="preserve">
-		<value>Password cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordMinimumLength" xml:space="preserve">
-		<value>Password must be at least 8 characters.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordUppercaseCharacter" xml:space="preserve">
-		<value>Password must contain at least one uppercase character.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordLowercaseCharacter" xml:space="preserve">
-		<value>Password must contain at least one lowercase character.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordNumber" xml:space="preserve">
-		<value>Password must contain at least one number.</value>
-	</data>
-	<data name="RegistrationErrorMessagePasswordWhitespace" xml:space="preserve">
-		<value>Password should not contain any spaces.</value>
-	</data>
-	<data name="RegistrationErrorMessageConfirmPasswordEmpty" xml:space="preserve">
-		<value>Confirm password cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RegistrationErrorMessageConfirmPasswordMismatch" xml:space="preserve">
-		<value>The passwords must match.</value>
-	</data>
-	<data name="VerificationErrorMessageVerificationCodeEmpty" xml:space="preserve">
-		<value>The verification code cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="VerificationErrorMessageVerificationCodeWhitespace" xml:space="preserve">
-		<value>The verification code cannot contain any spaces.</value>
-	</data>
-	<data name="VerificationErrorMessageVerificationCodeLength" xml:space="preserve">
-		<value>Incorrect number of characters. The verification code will be between 1 and 5 characters.</value>
-	</data>
-	<data name="VerificationErrorMessageVerificationCodeInvalidCharacters" xml:space="preserve">
-		<value>The verification code should only contain letters and numbers.</value>
-	</data>
-	<data name="LoginErrorMessageUsernameEmpty" xml:space="preserve">
-		<value>No username has been entered.</value>
-	</data>
-	<data name="LoginErrorMessagePasswordEmpty" xml:space="preserve">
-		<value>No password has been entered.</value>
-	</data>
-	<data name="RegisterPageAlreadyHaveAccount" xml:space="preserve">
-		<value>Already have an account?</value>
-	</data>
-	<data name="GameUserEntryListPageEmpty" xml:space="preserve">
-		<value>You currently have no games in </value>
-	</data>
-	<data name="GameUserEntryListPageEmptyServerError" xml:space="preserve">
-		<value>Failed to load your games due to an error on the server.</value>
-	</data>
-	<data name="GameUserEntryListPageEmptyGenericError" xml:space="preserve">
-		<value>Failed to load your games due to an unexpected error.</value>
-	</data>
-	<data name="Backlog" xml:space="preserve">
-		<value>Backlog</value>
-	</data>
-	<data name="Playing" xml:space="preserve">
-		<value>Playing</value>
-	</data>
-	<data name="Done" xml:space="preserve">
-		<value>Done</value>
-	</data>
-	<data name="Dropped" xml:space="preserve">
-		<value>Dropped</value>
-	</data>
-	<data name="GamePageErrorMessage" xml:space="preserve">
-		<value>Failed to load the selected game.</value>
-	</data>
-	<data name="GamePageCurrentlyIn" xml:space="preserve">
-		<value>Currently in</value>
-	</data>
-	<data name="GamePageSimilarGames" xml:space="preserve">
-		<value>Similar Games</value>
-	</data>
-	<data name="GamePageAddToLibrary" xml:space="preserve">
-		<value>Add to library</value>
-	</data>
-	<data name="GamePageOptions" xml:space="preserve">
-		<value>Options</value>
-	</data>
-	<data name="GameBarcodeScannerPageTitle" xml:space="preserve">
-		<value>Barcode</value>
-	</data>
-	<data name="GameBarcodeScannerPageInstructions" xml:space="preserve">
-		<value>Place the red line over the barcode you'd like to scan.</value>
-	</data>
-	<data name="GameBarcodeScannerPageRequestGame" xml:space="preserve">
-		<value>Can't find the scanned barcode in our library. Would you like to make a request?</value>
-	</data>
-	<data name="GameBarcodeScannerPageApiError" xml:space="preserve">
-		<value>An error occurred scanning the barcode. Please try again.</value>
-	</data>
-	<data name="GameBarcodeScannerPageGenericError" xml:space="preserve">
-		<value>An error occurred scanning the barcode.</value>
-	</data>
-	<data name="Yes" xml:space="preserve">
-		<value>Yes</value>
-	</data>
-	<data name="No" xml:space="preserve">
-		<value>No</value>
-	</data>
-	<data name="ForgottenPasswordPageInstructions" xml:space="preserve">
-		<value>Please enter the email address associated with your account.</value>
-	</data>
-	<data name="ForgottenPasswordPageEmailAddress" xml:space="preserve">
-		<value>Email address</value>
-	</data>
-	<data name="ForgottenPasswordPageSend" xml:space="preserve">
-		<value>Send</value>
-	</data>
-	<data name="ForgottenPasswordErrorMessageEmailAddressEmpty" xml:space="preserve">
-		<value>The email address cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="ForgottenPasswordErrorMessageEmailAddressWhitespace" xml:space="preserve">
-		<value>The email address cannot contain any spaces.</value>
-	</data>
-	<data name="ForgottenPasswordErrorMessageEmailAddressInvalid" xml:space="preserve">
-		<value>The email address is invalid.</value>
-	</data>
-	<data name="RecoveryPageInstructions" xml:space="preserve">
-		<value>An email has been sent to your email containing your recovery token. Enter below along with your username and new password.</value>
-	</data>
-	<data name="RecoveryPageTitle" xml:space="preserve">
-		<value>Recover Account</value>
-	</data>
-	<data name="RecoveryPageUsername" xml:space="preserve">
-		<value>Username</value>
-	</data>
-	<data name="RecoveryPageRecoveryToken" xml:space="preserve">
-		<value>Recovery token</value>
-	</data>
-	<data name="RecoveryPagePassword" xml:space="preserve">
-		<value>Password*</value>
-	</data>
-	<data name="RecoveryPageConfirmPassword" xml:space="preserve">
-		<value>Confirm password*</value>
-	</data>
-	<data name="RecoveryPageRecover" xml:space="preserve">
-		<value>Recover</value>
-	</data>
-	<data name="RecoveryPageRememberedPassword" xml:space="preserve">
-		<value>Remembered your password? </value>
-	</data>
-	<data name="RecoveryPageLogIn" xml:space="preserve">
-		<value>Log in</value>
-	</data>
-	<data name="RecoveryPagePrivacyPolicyAndTermsOfUse" xml:space="preserve">
-		<value>Privacy Policy &amp; Terms of Use</value>
-	</data>
-	<data name="RecoveryErrorMessageUsernameEmpty" xml:space="preserve">
-		<value>Username cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RecoveryErrorMessageUsernameWhitespace" xml:space="preserve">
-		<value>Username cannot contain any spaces.</value>
-	</data>
-	<data name="RecoveryErrorMessageUsernameLength" xml:space="preserve">
-		<value>Username must be between 1 and 255 characters.</value>
-	</data>
-	<data name="RecoveryErrorMessageUsernameInvalidCharacters" xml:space="preserve">
-		<value>The username can only contain letters, numbers, under-scores and hyphens.</value>
-	</data>
-	<data name="RecoveryErrorMessageRecoveryTokenEmpty" xml:space="preserve">
-		<value>Recovery token cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RecoveryErrorMessageRecoveryTokenWhitespace" xml:space="preserve">
-		<value>Recovery token cannot contain any spaces.</value>
-	</data>
-	<data name="RecoveryErrorMessageRecoveryTokenLength" xml:space="preserve">
-		<value>Recovery token must be exactly 30 characters long.</value>
-	</data>
-	<data name="RecoveryErrorMessageRecoveryTokenAlphanumeric" xml:space="preserve">
-		<value>Recovery token should only contain alphanumeric characters.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordEmpty" xml:space="preserve">
-		<value>Password cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordMinimumLength" xml:space="preserve">
-		<value>Password must be at least 8 characters.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordUppercaseCharacter" xml:space="preserve">
-		<value>Password must contain at least one uppercase character.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordLowercaseCharacter" xml:space="preserve">
-		<value>Password must contain at least one lowercase character.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordNumber" xml:space="preserve">
-		<value>Password must contain at least one number.</value>
-	</data>
-	<data name="RecoveryErrorMessagePasswordWhitespace" xml:space="preserve">
-		<value>Password should not contain any spaces.</value>
-	</data>
-	<data name="RecoveryErrorMessageConfirmPasswordEmpty" xml:space="preserve">
-		<value>Confirm password cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="RecoveryErrorMessageConfirmPasswordMismatch" xml:space="preserve">
-		<value>The passwords must match.</value>
-	</data>
-	<data name="GameLibraryListPageTitle" xml:space="preserve">
-		<value>Library</value>
-	</data>
-	<data name="GameLibraryListPageInstructions" xml:space="preserve">
-		<value>Discover new games to add to your library</value>
-	</data>
-	<data name="GameLibraryListPageCantFindInstructions" xml:space="preserve">
-		<value>Can't find what you're looking for?</value>
-	</data>
-	<data name="GameLibraryListPageEmptyServerError" xml:space="preserve">
-		<value>Failed to load games due to an error on the server.</value>
-	</data>
-	<data name="GameLibraryListPageEmptyGenericError" xml:space="preserve">
-		<value>Failed to load games due to an unexpected error.</value>
-	</data>
-	<data name="GameLibraryListPageRequestGame" xml:space="preserve">
-		<value>Request Game</value>
-	</data>
-	<data name="BaseMasterDetailContentPageHome" xml:space="preserve">
-		<value>Home</value>
-	</data>
-	<data name="BaseMasterDetailContentPageBooks" xml:space="preserve">
-		<value>Books</value>
-	</data>
-	<data name="BaseMasterDetailContentPageAnime" xml:space="preserve">
-		<value>Anime</value>
-	</data>
-	<data name="BaseMasterDetailContentPageManga" xml:space="preserve">
-		<value>Manga</value>
-	</data>
-	<data name="BaseMasterDetailContentPageGames" xml:space="preserve">
-		<value>Games</value>
-	</data>
-	<data name="BaseMasterDetailContentPageSettings" xml:space="preserve">
-		<value>Settings</value>
-	</data>
-	<data name="BaseMasterDetailContentPageLogout" xml:space="preserve">
-		<value>Log out</value>
-	</data>
-	<data name="GameRequestPageGameTitle" xml:space="preserve">
-		<value>Game Title</value>
-	</data>
-	<data name="GameRequestPageAdditionalComments" xml:space="preserve">
-		<value>Additional comments</value>
-	</data>
-	<data name="GameRequestPageSubmit" xml:space="preserve">
-		<value>Submit</value>
-	</data>
-	<data name="GameRequestPageRequestComplete" xml:space="preserve">
-		<value>Thank you for your request. An admin will add the request game to the library as soon as possible. You will receive a notification when the request has been completed.</value>
-	</data>
-	<data name="GameRequestErrorMessageTitleEmpty" xml:space="preserve">
-		<value>The title cannot be empty or only contain whitespace.</value>
-	</data>
-	<data name="GameRequestErrorMessageTitleMaxLength" xml:space="preserve">
-		<value>The title cannot exceed 255 characters.</value>
-	</data>
-	<data name="GameRequestErrorMessageCommentsMaxLength" xml:space="preserve">
-		<value>The comments cannot exceed 2048 characters.</value>
-	</data>
-	<data name="AddGameErrorMessagePlatformNull" xml:space="preserve">
-		<value>The platform cannot be empty.</value>
-	</data>
-	<data name="AddGameErrorMessageStatusNone" xml:space="preserve">
-		<value>The status cannot be empty.</value>
-	</data>
-	<data name="AddGamePagePlatform" xml:space="preserve">
-		<value>Platform</value>
-	</data>
-	<data name="AddGamePageStatus" xml:space="preserve">
-		<value>Status</value>
-	</data>
-	<data name="AddGamePageAdd" xml:space="preserve">
-		<value>Add</value>
-	</data>
-	<data name="GameOptionsPageStatus" xml:space="preserve">
-		<value>Status</value>
-	</data>
-	<data name="GameOptionsPageUpdate" xml:space="preserve">
-		<value>Update</value>
-	</data>
-	<data name="GameOptionsPageDelete" xml:space="preserve">
-		<value>Delete</value>
-	</data>
-	<data name="GameLibraryTabbedPage" xml:space="preserve">
-		<value>Add Game</value>
-	</data>
-	<data name="GameUserEntriesTabbedPageTitle" xml:space="preserve">
-		<value>Games</value>
-	</data>
-	<data name="SettingsPageTitle" xml:space="preserve">
-		<value>Settings</value>
-	</data>
-	<data name="SettingsPageAccountSubtitle" xml:space="preserve">
-		<value>Account</value>
-	</data>
-	<data name="SettingsPageChangePassword" xml:space="preserve">
-		<value>Change Password</value>
-	</data>
-	<data name="ChangePasswordPageTitle" xml:space="preserve">
-		<value>Change password</value>
-	</data>
-	<data name="ChangePasswordPageCurrentPassword" xml:space="preserve">
-		<value>Current password</value>
-	</data>
-	<data name="ChangePasswordPageNewPassword" xml:space="preserve">
-		<value>New password</value>
-	</data>
-	<data name="ChangePasswordPageConfirmNewPassword" xml:space="preserve">
-		<value>Confirm new password</value>
-	</data>
-	<data name="ChangePasswordPageChange" xml:space="preserve">
-		<value>Change</value>
-	</data>
-	<data name="ChangePasswordPageResetToken" xml:space="preserve">
-		<value>Reset token</value>
-	</data>
-	<data name="RequestChangePasswordPageTitle" xml:space="preserve">
-		<value>Request change password</value>
-	</data>
-	<data name="RequestChangePasswordPageInstructions" xml:space="preserve">
-		<value>Tap below to receive your token to change your password.</value>
-	</data>
-	<data name="RequestChangePasswordPageSend" xml:space="preserve">
-		<value>Send</value>
-	</data>
-	<data name="RequestChangePasswordPageAlreadyHaveToken" xml:space="preserve">
-		<value>Already have a token?</value>
-	</data>
-	<data name="RequestChangePasswordPageTapHere" xml:space="preserve">
-		<value>Tap here</value>
-	</data>
-	<data name="ChangePasswordPageSuccess" xml:space="preserve">
-		<value>Password successfully changed. Please login with your new credentials.</value>
-	</data>
-	<data name="SettingsPageChangeEmailAddress" xml:space="preserve">
-		<value>Change Email Address</value>
-	</data>
-	<data name="ChangeEmailAddressPageSuccess" xml:space="preserve">
-		<value>Email address successfully changed. You will have received a new verification email. Please login and verify your account.</value>
-	</data>
-	<data name="ChangeEmailAddressPageInstructions" xml:space="preserve">
-		<value>Enter your current email address below to receive an email containing a token, allowing you to update it.</value>
-	</data>
-	<data name="ChangeEmailAddressPageNewEmailAddress" xml:space="preserve">
-		<value>New email address</value>
-	</data>
-	<data name="ChangeEmailAddressPageUpdate" xml:space="preserve">
-		<value>Update</value>
-	</data>
-	<data name="ChangeEmailAddressPageTitle" xml:space="preserve">
-		<value>Change Email Address</value>
-	</data>
-	<data name="HomePageSubtitle" xml:space="preserve">
-		<value>Keep track of all your collections here in your library.</value>
-	</data>
-	<data name="SettingsPageDeleteMyAccount" xml:space="preserve">
-		<value>Delete Account</value>
-	</data>
-	<data name="DeleteAccountPageDeleteMe" xml:space="preserve">
-		<value>DELETE ME</value>
-	</data>
-	<data name="DeleteAccountPageTitle" xml:space="preserve">
-		<value>Delete account</value>
-	</data>
-	<data name="DeleteAccountPageFirstInstructions" xml:space="preserve">
-		<value>Account deletion cannot be reversed. If you wish to continue enter  </value>
-	</data>
-	<data name="DeleteAccountPageDelete" xml:space="preserve">
-		<value>Delete</value>
-	</data>
-	<data name="DeleteAccountIncorrectDeleteMessage" xml:space="preserve">
-		<value>DELETE ME entered incorrectly.</value>
-	</data>
-	<data name="DeleteAccountPageSecondInstructions" xml:space="preserve">
-		<value> and tap Delete below to continue.</value>
-	</data>
-	<data name="DeleteAccountPageSuccess" xml:space="preserve">
-		<value>Your account has been successfully deleted.</value>
-	</data>
-	<data name="GameLibraryPageEmptySearchResult" xml:space="preserve">
-		<value>Sorry we couldn't find any results for "{0}"</value>
-	</data>
-	<data name="GameLibraryListPageSearchPlaceholder" xml:space="preserve">
-		<value>Search</value>
-	</data>
-	<data name="GamePageReleaseDateNotReleased" xml:space="preserve">
-		<value>Not released</value>
-	</data>
-	<data name="GameOptionsPageNotInLibrary" xml:space="preserve">
-		<value>Is currently not in your library</value>
-	</data>
-	<data name="GameOptionsPageInLibrary" xml:space="preserve">
-		<value>Is currently in your library</value>
-	</data>
-	<data name="GameOptionsPageSelectPlatforms" xml:space="preserve">
-		<value>Select platforms</value>
-	</data>
-	<data name="GameOptionsPageAdd" xml:space="preserve">
-		<value>Add</value>
-	</data>
-	<data name="GameOptionsPageNoSelectedPlatforms" xml:space="preserve">
-		<value>*No platforms have been selected.</value>
-	</data>
-	<data name="GameOptionsPageNoSelectedStatus" xml:space="preserve">
-		<value>*No status has been selected.</value>
-	</data>
-	<data name="GameOptionsPageGameAdded" xml:space="preserve">
-		<value>{0} has been added to your library.</value>
-	</data>
-	<data name="GameOptionsPageGameRemoved" xml:space="preserve">
-		<value>{0} has been removed from your library.</value>
-	</data>
-	<data name="GameOptionsPageRating" xml:space="preserve">
-		<value>Rating</value>
-	</data>
-	<data name="GameOptionsPageRemoveRating" xml:space="preserve">
-		<value>Remove Rating</value>
-	</data>
-	<data name="GameOptionsPageRemoveFromLibrary" xml:space="preserve">
-		<value>Remove from library</value>
-	</data>
-	<data name="GamePageAgeRating" xml:space="preserve">
-		<value>Age rating</value>
-	</data>
-	<data name="GamePageGameModes" xml:space="preserve">
-		<value>Game modes</value>
-	</data>
-	<data name="GamePageFranchise" xml:space="preserve">
-		<value>Franchise</value>
-	</data>
-	<data name="GamePageReleaseDates" xml:space="preserve">
-		<value>Release dates</value>
-	</data>
-	<data name="PasswordRules" xml:space="preserve">
-		<value>*Password should contain at least 8 characters, both lowercase and uppercase letters and atleast one number.</value>
-	</data>
-	<data name="ForgottenPasswordPageTitle" xml:space="preserve">
-		<value>Forgotten Password</value>
-	</data>
-	<data name="ForgottenPasswordPageAlreadyHaveToken" xml:space="preserve">
-		<value>Already have a recovery token?</value>
-	</data>
-	<data name="ForgottenPasswordPageTapHere" xml:space="preserve">
-		<value>Tap here</value>
-	</data>
-	<data name="GameRequestPageTitle" xml:space="preserve">
-		<value>Request Game</value>
-	</data>
-	<data name="GameRequestPageInstructionsOne" xml:space="preserve">
-		<value>Send us your requests to add to our game library so you can add them to your collection.</value>
-	</data>
-	<data name="GameRequestPageInstructionsTwo" xml:space="preserve">
-		<value>Please include as much information as possible so our administrators can process your requests more quickly.</value>
-	</data>
-	<data name="SettingsPageWelcome" xml:space="preserve">
-		<value>Welcome, </value>
-	</data>
-	<data name="SettingsPageInstructions" xml:space="preserve">
-		<value> please find settings below to make changes to your account.</value>
-	</data>
-	<data name="SettingsPageChangeUsername" xml:space="preserve">
-		<value>Change Username</value>
-	</data>
-	<data name="GamePageReleaseDateAmerica" xml:space="preserve">
-		<value>America: </value>
-	</data>
-	<data name="GamePageReleaseDateJapan" xml:space="preserve">
-		<value>Japan: </value>
-	</data>
-	<data name="GamePageReleaseDateEurope" xml:space="preserve">
-		<value>Europe: </value>
-	</data>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TrakTitle" xml:space="preserve">
+    <value>Trak</value>
+  </data>
+  <data name="LoginPageLogIn" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="LoginPageUsernameOrEmail" xml:space="preserve">
+    <value>Username or Email</value>
+  </data>
+  <data name="LoginPagePassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="LoginPageForgottenPassword" xml:space="preserve">
+    <value>Forgotten password?</value>
+  </data>
+  <data name="LoginPageDontHaveAnAccount" xml:space="preserve">
+    <value>Don't have an account? </value>
+  </data>
+  <data name="LoginPageJoinNow" xml:space="preserve">
+    <value>Join Now</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>Games, Books, Manga, Anime</value>
+  </data>
+  <data name="RegisterPageTitle" xml:space="preserve">
+    <value>Create Account</value>
+  </data>
+  <data name="RegisterPageUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="RegisterPageEmailAddress" xml:space="preserve">
+    <value>Email address</value>
+  </data>
+  <data name="RegisterPagePassword" xml:space="preserve">
+    <value>Password*</value>
+  </data>
+  <data name="RegisterPageConfirmPassword" xml:space="preserve">
+    <value>Confirm password*</value>
+  </data>
+  <data name="RegisterPageSignUp" xml:space="preserve">
+    <value>Sign up</value>
+  </data>
+  <data name="RegisterPagePrivacyPolicyAndTermsOfUse" xml:space="preserve">
+    <value>Privacy Policy &amp; Terms of Use</value>
+  </data>
+  <data name="RegisterPageLogIn" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="LoginPageTitle" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="VerificationPageTitle" xml:space="preserve">
+    <value>Verify Account</value>
+  </data>
+  <data name="VerificationPageConfirmation" xml:space="preserve">
+    <value>Thank you, we have now sent you a confirmation email with your verification code.</value>
+  </data>
+  <data name="VerificationPageVerificationCode" xml:space="preserve">
+    <value>Verification Code</value>
+  </data>
+  <data name="VerificationPageVerify" xml:space="preserve">
+    <value>Verify</value>
+  </data>
+  <data name="VerificationPageHaventReceivedEmail" xml:space="preserve">
+    <value>Haven't received an email? </value>
+  </data>
+  <data name="VerificationPageSendAgain" xml:space="preserve">
+    <value>Send again</value>
+  </data>
+  <data name="ErrorMessageIncorrectCredentials" xml:space="preserve">
+    <value>Your credentials were incorrect. Please try again.</value>
+  </data>
+  <data name="ErrorMessageApiError" xml:space="preserve">
+    <value>An error occurred making the request. Please try again.</value>
+  </data>
+  <data name="ErrorMessageGeneric" xml:space="preserve">
+    <value>An error occurred making the request.</value>
+  </data>
+  <data name="RegistrationErrorMessageUsernameEmpty" xml:space="preserve">
+    <value>Username cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RegistrationErrorMessageUsernameWhitespace" xml:space="preserve">
+    <value>Username cannot contain any spaces.</value>
+  </data>
+  <data name="RegistrationErrorMessageUsernameLength" xml:space="preserve">
+    <value>Username must be between 1 and 255 characters.</value>
+  </data>
+  <data name="RegistrationErrorMessageUsernameInvalidCharacters" xml:space="preserve">
+    <value>The username can only contain letters, numbers, under-scores and hyphens.</value>
+  </data>
+  <data name="RegistrationErrorMessageEmailAddressEmpty" xml:space="preserve">
+    <value>Email address cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RegistrationErrorMessageEmailAddressInvalid" xml:space="preserve">
+    <value>Email address is invalid.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordEmpty" xml:space="preserve">
+    <value>Password cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordMinimumLength" xml:space="preserve">
+    <value>Password must be at least 8 characters.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordUppercaseCharacter" xml:space="preserve">
+    <value>Password must contain at least one uppercase character.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordLowercaseCharacter" xml:space="preserve">
+    <value>Password must contain at least one lowercase character.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordNumber" xml:space="preserve">
+    <value>Password must contain at least one number.</value>
+  </data>
+  <data name="RegistrationErrorMessagePasswordWhitespace" xml:space="preserve">
+    <value>Password should not contain any spaces.</value>
+  </data>
+  <data name="RegistrationErrorMessageConfirmPasswordEmpty" xml:space="preserve">
+    <value>Confirm password cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RegistrationErrorMessageConfirmPasswordMismatch" xml:space="preserve">
+    <value>The passwords must match.</value>
+  </data>
+  <data name="VerificationErrorMessageVerificationCodeEmpty" xml:space="preserve">
+    <value>The verification code cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="VerificationErrorMessageVerificationCodeWhitespace" xml:space="preserve">
+    <value>The verification code cannot contain any spaces.</value>
+  </data>
+  <data name="VerificationErrorMessageVerificationCodeLength" xml:space="preserve">
+    <value>Incorrect number of characters. The verification code will be between 1 and 5 characters.</value>
+  </data>
+  <data name="VerificationErrorMessageVerificationCodeInvalidCharacters" xml:space="preserve">
+    <value>The verification code should only contain letters and numbers.</value>
+  </data>
+  <data name="LoginErrorMessageUsernameEmpty" xml:space="preserve">
+    <value>No username has been entered.</value>
+  </data>
+  <data name="LoginErrorMessagePasswordEmpty" xml:space="preserve">
+    <value>No password has been entered.</value>
+  </data>
+  <data name="RegisterPageAlreadyHaveAccount" xml:space="preserve">
+    <value>Already have an account?</value>
+  </data>
+  <data name="GameUserEntryListPageEmpty" xml:space="preserve">
+    <value>You currently have no games in </value>
+  </data>
+  <data name="GameUserEntryListPageEmptyServerError" xml:space="preserve">
+    <value>Failed to load your games due to an error on the server.</value>
+  </data>
+  <data name="GameUserEntryListPageEmptyGenericError" xml:space="preserve">
+    <value>Failed to load your games due to an unexpected error.</value>
+  </data>
+  <data name="Backlog" xml:space="preserve">
+    <value>Backlog</value>
+  </data>
+  <data name="Playing" xml:space="preserve">
+    <value>Playing</value>
+  </data>
+  <data name="Done" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="Dropped" xml:space="preserve">
+    <value>Dropped</value>
+  </data>
+  <data name="GamePageErrorMessage" xml:space="preserve">
+    <value>Failed to load the selected game.</value>
+  </data>
+  <data name="GamePageCurrentlyIn" xml:space="preserve">
+    <value>Currently in</value>
+  </data>
+  <data name="GamePageSimilarGames" xml:space="preserve">
+    <value>Similar Games</value>
+  </data>
+  <data name="GamePageAddToLibrary" xml:space="preserve">
+    <value>Add to library</value>
+  </data>
+  <data name="GamePageOptions" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="GameBarcodeScannerPageTitle" xml:space="preserve">
+    <value>Barcode</value>
+  </data>
+  <data name="GameBarcodeScannerPageInstructions" xml:space="preserve">
+    <value>Place the red line over the barcode you'd like to scan.</value>
+  </data>
+  <data name="GameBarcodeScannerPageRequestGame" xml:space="preserve">
+    <value>Can't find the scanned barcode in our library. Would you like to make a request?</value>
+  </data>
+  <data name="GameBarcodeScannerPageApiError" xml:space="preserve">
+    <value>An error occurred scanning the barcode. Please try again.</value>
+  </data>
+  <data name="GameBarcodeScannerPageGenericError" xml:space="preserve">
+    <value>An error occurred scanning the barcode.</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="ForgottenPasswordPageInstructions" xml:space="preserve">
+    <value>Please enter the email address associated with your account.</value>
+  </data>
+  <data name="ForgottenPasswordPageEmailAddress" xml:space="preserve">
+    <value>Email address</value>
+  </data>
+  <data name="ForgottenPasswordPageSend" xml:space="preserve">
+    <value>Send</value>
+  </data>
+  <data name="ForgottenPasswordErrorMessageEmailAddressEmpty" xml:space="preserve">
+    <value>The email address cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="ForgottenPasswordErrorMessageEmailAddressWhitespace" xml:space="preserve">
+    <value>The email address cannot contain any spaces.</value>
+  </data>
+  <data name="ForgottenPasswordErrorMessageEmailAddressInvalid" xml:space="preserve">
+    <value>The email address is invalid.</value>
+  </data>
+  <data name="RecoveryPageInstructions" xml:space="preserve">
+    <value>An email has been sent to your email containing your recovery token. Enter below along with your username and new password.</value>
+  </data>
+  <data name="RecoveryPageTitle" xml:space="preserve">
+    <value>Recover Account</value>
+  </data>
+  <data name="RecoveryPageUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="RecoveryPageRecoveryToken" xml:space="preserve">
+    <value>Recovery token</value>
+  </data>
+  <data name="RecoveryPagePassword" xml:space="preserve">
+    <value>Password*</value>
+  </data>
+  <data name="RecoveryPageConfirmPassword" xml:space="preserve">
+    <value>Confirm password*</value>
+  </data>
+  <data name="RecoveryPageRecover" xml:space="preserve">
+    <value>Recover</value>
+  </data>
+  <data name="RecoveryPageRememberedPassword" xml:space="preserve">
+    <value>Remembered your password? </value>
+  </data>
+  <data name="RecoveryPageLogIn" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="RecoveryPagePrivacyPolicyAndTermsOfUse" xml:space="preserve">
+    <value>Privacy Policy &amp; Terms of Use</value>
+  </data>
+  <data name="RecoveryErrorMessageUsernameEmpty" xml:space="preserve">
+    <value>Username cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RecoveryErrorMessageUsernameWhitespace" xml:space="preserve">
+    <value>Username cannot contain any spaces.</value>
+  </data>
+  <data name="RecoveryErrorMessageUsernameLength" xml:space="preserve">
+    <value>Username must be between 1 and 255 characters.</value>
+  </data>
+  <data name="RecoveryErrorMessageUsernameInvalidCharacters" xml:space="preserve">
+    <value>The username can only contain letters, numbers, under-scores and hyphens.</value>
+  </data>
+  <data name="RecoveryErrorMessageRecoveryTokenEmpty" xml:space="preserve">
+    <value>Recovery token cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RecoveryErrorMessageRecoveryTokenWhitespace" xml:space="preserve">
+    <value>Recovery token cannot contain any spaces.</value>
+  </data>
+  <data name="RecoveryErrorMessageRecoveryTokenLength" xml:space="preserve">
+    <value>Recovery token must be exactly 30 characters long.</value>
+  </data>
+  <data name="RecoveryErrorMessageRecoveryTokenAlphanumeric" xml:space="preserve">
+    <value>Recovery token should only contain alphanumeric characters.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordEmpty" xml:space="preserve">
+    <value>Password cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordMinimumLength" xml:space="preserve">
+    <value>Password must be at least 8 characters.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordUppercaseCharacter" xml:space="preserve">
+    <value>Password must contain at least one uppercase character.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordLowercaseCharacter" xml:space="preserve">
+    <value>Password must contain at least one lowercase character.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordNumber" xml:space="preserve">
+    <value>Password must contain at least one number.</value>
+  </data>
+  <data name="RecoveryErrorMessagePasswordWhitespace" xml:space="preserve">
+    <value>Password should not contain any spaces.</value>
+  </data>
+  <data name="RecoveryErrorMessageConfirmPasswordEmpty" xml:space="preserve">
+    <value>Confirm password cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="RecoveryErrorMessageConfirmPasswordMismatch" xml:space="preserve">
+    <value>The passwords must match.</value>
+  </data>
+  <data name="GameLibraryListPageTitle" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="GameLibraryListPageInstructions" xml:space="preserve">
+    <value>Discover new games to add to your library</value>
+  </data>
+  <data name="GameLibraryListPageCantFindInstructions" xml:space="preserve">
+    <value>Can't find what you're looking for?</value>
+  </data>
+  <data name="GameLibraryListPageEmptyServerError" xml:space="preserve">
+    <value>Failed to load games due to an error on the server.</value>
+  </data>
+  <data name="GameLibraryListPageEmptyGenericError" xml:space="preserve">
+    <value>Failed to load games due to an unexpected error.</value>
+  </data>
+  <data name="GameLibraryListPageRequestGame" xml:space="preserve">
+    <value>Request Game</value>
+  </data>
+  <data name="BaseMasterDetailContentPageHome" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="BaseMasterDetailContentPageBooks" xml:space="preserve">
+    <value>Books</value>
+  </data>
+  <data name="BaseMasterDetailContentPageAnime" xml:space="preserve">
+    <value>Anime</value>
+  </data>
+  <data name="BaseMasterDetailContentPageManga" xml:space="preserve">
+    <value>Manga</value>
+  </data>
+  <data name="BaseMasterDetailContentPageGames" xml:space="preserve">
+    <value>Games</value>
+  </data>
+  <data name="BaseMasterDetailContentPageSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="BaseMasterDetailContentPageLogout" xml:space="preserve">
+    <value>Log out</value>
+  </data>
+  <data name="GameRequestPageGameTitle" xml:space="preserve">
+    <value>Game Title</value>
+  </data>
+  <data name="GameRequestPageAdditionalComments" xml:space="preserve">
+    <value>Additional comments</value>
+  </data>
+  <data name="GameRequestPageSubmit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="GameRequestPageRequestComplete" xml:space="preserve">
+    <value>Thank you for your request. An admin will add the request game to the library as soon as possible. You will receive a notification when the request has been completed.</value>
+  </data>
+  <data name="GameRequestErrorMessageTitleEmpty" xml:space="preserve">
+    <value>The title cannot be empty or only contain whitespace.</value>
+  </data>
+  <data name="GameRequestErrorMessageTitleMaxLength" xml:space="preserve">
+    <value>The title cannot exceed 255 characters.</value>
+  </data>
+  <data name="GameRequestErrorMessageCommentsMaxLength" xml:space="preserve">
+    <value>The comments cannot exceed 2048 characters.</value>
+  </data>
+  <data name="AddGameErrorMessagePlatformNull" xml:space="preserve">
+    <value>The platform cannot be empty.</value>
+  </data>
+  <data name="AddGameErrorMessageStatusNone" xml:space="preserve">
+    <value>The status cannot be empty.</value>
+  </data>
+  <data name="AddGamePagePlatform" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="AddGamePageStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="AddGamePageAdd" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="GameOptionsPageStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="GameOptionsPageUpdate" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="GameOptionsPageDelete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="GameLibraryTabbedPage" xml:space="preserve">
+    <value>Add Game</value>
+  </data>
+  <data name="GameUserEntriesTabbedPageTitle" xml:space="preserve">
+    <value>Games</value>
+  </data>
+  <data name="SettingsPageTitle" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsPageAccountSubtitle" xml:space="preserve">
+    <value>Account</value>
+  </data>
+  <data name="SettingsPageChangePassword" xml:space="preserve">
+    <value>Change Password</value>
+  </data>
+  <data name="ChangePasswordPageTitle" xml:space="preserve">
+    <value>Change password</value>
+  </data>
+  <data name="ChangePasswordPageCurrentPassword" xml:space="preserve">
+    <value>Current password</value>
+  </data>
+  <data name="ChangePasswordPageNewPassword" xml:space="preserve">
+    <value>New password</value>
+  </data>
+  <data name="ChangePasswordPageConfirmNewPassword" xml:space="preserve">
+    <value>Confirm new password</value>
+  </data>
+  <data name="ChangePasswordPageChange" xml:space="preserve">
+    <value>Change</value>
+  </data>
+  <data name="ChangePasswordPageResetToken" xml:space="preserve">
+    <value>Reset token</value>
+  </data>
+  <data name="RequestChangePasswordPageTitle" xml:space="preserve">
+    <value>Request change password</value>
+  </data>
+  <data name="RequestChangePasswordPageInstructions" xml:space="preserve">
+    <value>Tap below to receive your token to change your password.</value>
+  </data>
+  <data name="RequestChangePasswordPageSend" xml:space="preserve">
+    <value>Send</value>
+  </data>
+  <data name="RequestChangePasswordPageAlreadyHaveToken" xml:space="preserve">
+    <value>Already have a token?</value>
+  </data>
+  <data name="RequestChangePasswordPageTapHere" xml:space="preserve">
+    <value>Tap here</value>
+  </data>
+  <data name="ChangePasswordPageSuccess" xml:space="preserve">
+    <value>Password successfully changed. Please login with your new credentials.</value>
+  </data>
+  <data name="SettingsPageChangeEmailAddress" xml:space="preserve">
+    <value>Change Email Address</value>
+  </data>
+  <data name="ChangeEmailAddressPageSuccess" xml:space="preserve">
+    <value>Email address successfully changed. You will have received a new verification email. Please login and verify your account.</value>
+  </data>
+  <data name="ChangeEmailAddressPageInstructions" xml:space="preserve">
+    <value>Enter your current email address below to receive an email containing a token, allowing you to update it.</value>
+  </data>
+  <data name="ChangeEmailAddressPageNewEmailAddress" xml:space="preserve">
+    <value>New email address</value>
+  </data>
+  <data name="ChangeEmailAddressPageUpdate" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="ChangeEmailAddressPageTitle" xml:space="preserve">
+    <value>Change Email Address</value>
+  </data>
+  <data name="HomePageSubtitle" xml:space="preserve">
+    <value>Keep track of all your collections here in your library.</value>
+  </data>
+  <data name="SettingsPageDeleteMyAccount" xml:space="preserve">
+    <value>Delete Account</value>
+  </data>
+  <data name="DeleteAccountPageDeleteMe" xml:space="preserve">
+    <value>DELETE ME</value>
+  </data>
+  <data name="DeleteAccountPageTitle" xml:space="preserve">
+    <value>Delete account</value>
+  </data>
+  <data name="DeleteAccountPageFirstInstructions" xml:space="preserve">
+    <value>Account deletion cannot be reversed. If you wish to continue enter  </value>
+  </data>
+  <data name="DeleteAccountPageDelete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteAccountIncorrectDeleteMessage" xml:space="preserve">
+    <value>DELETE ME entered incorrectly.</value>
+  </data>
+  <data name="DeleteAccountPageSecondInstructions" xml:space="preserve">
+    <value> and tap Delete below to continue.</value>
+  </data>
+  <data name="DeleteAccountPageSuccess" xml:space="preserve">
+    <value>Your account has been successfully deleted.</value>
+  </data>
+  <data name="GameLibraryPageEmptySearchResult" xml:space="preserve">
+    <value>Sorry we couldn't find any results for "{0}"</value>
+  </data>
+  <data name="GameLibraryListPageSearchPlaceholder" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="GamePageReleaseDateNotReleased" xml:space="preserve">
+    <value>Not released</value>
+  </data>
+  <data name="GameOptionsPageNotInLibrary" xml:space="preserve">
+    <value>Is currently not in your library</value>
+  </data>
+  <data name="GameOptionsPageInLibrary" xml:space="preserve">
+    <value>Is currently in your library</value>
+  </data>
+  <data name="GameOptionsPageSelectPlatforms" xml:space="preserve">
+    <value>Select platforms</value>
+  </data>
+  <data name="GameOptionsPageAdd" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="GameOptionsPageNoSelectedPlatforms" xml:space="preserve">
+    <value>*No platforms have been selected.</value>
+  </data>
+  <data name="GameOptionsPageNoSelectedStatus" xml:space="preserve">
+    <value>*No status has been selected.</value>
+  </data>
+  <data name="GameOptionsPageGameAdded" xml:space="preserve">
+    <value>{0} has been added to your library.</value>
+  </data>
+  <data name="GameOptionsPageGameRemoved" xml:space="preserve">
+    <value>{0} has been removed from your library.</value>
+  </data>
+  <data name="GameOptionsPageRating" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="GameOptionsPageRemoveRating" xml:space="preserve">
+    <value>Remove Rating</value>
+  </data>
+  <data name="GameOptionsPageRemoveFromLibrary" xml:space="preserve">
+    <value>Remove from library</value>
+  </data>
+  <data name="GamePageAgeRating" xml:space="preserve">
+    <value>Age rating</value>
+  </data>
+  <data name="GamePageGameModes" xml:space="preserve">
+    <value>Game modes</value>
+  </data>
+  <data name="GamePageFranchise" xml:space="preserve">
+    <value>Franchise</value>
+  </data>
+  <data name="GamePageReleaseDates" xml:space="preserve">
+    <value>Release dates</value>
+  </data>
+  <data name="PasswordRules" xml:space="preserve">
+    <value>*Password should contain at least 8 characters, both lowercase and uppercase letters and atleast one number.</value>
+  </data>
+  <data name="ForgottenPasswordPageTitle" xml:space="preserve">
+    <value>Forgotten Password</value>
+  </data>
+  <data name="ForgottenPasswordPageAlreadyHaveToken" xml:space="preserve">
+    <value>Already have a recovery token?</value>
+  </data>
+  <data name="ForgottenPasswordPageTapHere" xml:space="preserve">
+    <value>Tap here</value>
+  </data>
+  <data name="GameRequestPageTitle" xml:space="preserve">
+    <value>Request Game</value>
+  </data>
+  <data name="GameRequestPageInstructionsOne" xml:space="preserve">
+    <value>Send us your requests to add to our game library so you can add them to your collection.</value>
+  </data>
+  <data name="GameRequestPageInstructionsTwo" xml:space="preserve">
+    <value>Please include as much information as possible so our administrators can process your requests more quickly.</value>
+  </data>
+  <data name="SettingsPageWelcome" xml:space="preserve">
+    <value>Welcome, </value>
+  </data>
+  <data name="SettingsPageInstructions" xml:space="preserve">
+    <value> please find settings below to make changes to your account.</value>
+  </data>
+  <data name="SettingsPageChangeUsername" xml:space="preserve">
+    <value>Change Username</value>
+  </data>
+  <data name="GamePageReleaseDateAmerica" xml:space="preserve">
+    <value>America: </value>
+  </data>
+  <data name="GamePageReleaseDateJapan" xml:space="preserve">
+    <value>Japan: </value>
+  </data>
+  <data name="GamePageReleaseDateEurope" xml:space="preserve">
+    <value>Europe: </value>
+  </data>
+  <data name="GameUserEntryFilterPageAgeRatings" xml:space="preserve">
+    <value>Age ratings</value>
+  </data>
+  <data name="GameUserEntryFilterPageApply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="GameUserEntryFilterPageGameModes" xml:space="preserve">
+    <value>Game modes</value>
+  </data>
+  <data name="GameUserEntryFilterPageGenres" xml:space="preserve">
+    <value>Genres</value>
+  </data>
+  <data name="GameUserEntryFilterPagePlatforms" xml:space="preserve">
+    <value>Platforms</value>
+  </data>
+  <data name="GameUserEntryFilterPageStatuses" xml:space="preserve">
+    <value>Statuses</value>
+  </data>
+  <data name="GameUserEntryFilterPageTitle" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GamePageNotRatedYet" xml:space="preserve">
+    <value>Not rated yet:</value>
+  </data>
+  <data name="GameUserEntryListPageAddGame" xml:space="preserve">
+    <value>Add game</value>
+  </data>
+  <data name="GameUserEntryListPageTitle" xml:space="preserve">
+    <value>Entries</value>
+  </data>
+  <data name="GameUserEntryListPageEmptyResults" xml:space="preserve">
+    <value>No entries match the given query.</value>
+  </data>
 </root>

--- a/SparkyStudios.TrakLibrary/App.xaml.cs
+++ b/SparkyStudios.TrakLibrary/App.xaml.cs
@@ -20,7 +20,6 @@ using SparkyStudios.TrakLibrary.Views;
 using SparkyStudios.TrakLibrary.Views.Games;
 using SparkyStudios.TrakLibrary.Views.Login;
 using SparkyStudios.TrakLibrary.Views.Settings;
-using Xamarin.Forms;
 
 namespace SparkyStudios.TrakLibrary
 {
@@ -99,6 +98,9 @@ namespace SparkyStudios.TrakLibrary
             containerRegistry.RegisterForNavigation<GameBarcodeScannerPage, GameBarcodeScannerViewModel>();
             containerRegistry.RegisterForNavigation<GamePage, GameViewModel>();
             containerRegistry.RegisterForNavigation<GameOptionsPage, GameOptionsViewModel>();
+            containerRegistry.RegisterForNavigation<GameUserEntryTabbedListPage, GameUserEntryTabbedListViewModel>();
+            containerRegistry.RegisterForNavigation<GameUserEntryListPage, GameUserEntryListViewModel>();
+            containerRegistry.RegisterForNavigation<GameUserEntryFilterPage, GameUserEntryFilterViewModel>();
         }
     }
 }

--- a/SparkyStudios.TrakLibrary/BaseNavigationPage.xaml
+++ b/SparkyStudios.TrakLibrary/BaseNavigationPage.xaml
@@ -6,4 +6,5 @@
     xmlns:viewModel="clr-namespace:SparkyStudios.TrakLibrary.ViewModel;assembly=SparkyStudios.TrakLibrary.ViewModel"
     Title="Title"
     x:DataType="viewModel:NavigationViewModel"
-    BarTextColor="{StaticResource TrakWhite}" />
+    BarTextColor="{StaticResource TrakWhite}"
+    NavigationPage.BackButtonTitle=" " />

--- a/SparkyStudios.TrakLibrary/Controls/Common/FilterControl.xaml
+++ b/SparkyStudios.TrakLibrary/Controls/Common/FilterControl.xaml
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Grid
+    x:Class="SparkyStudios.TrakLibrary.Controls.Common.FilterControl"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:behaviors="http://prismlibrary.com"
+    xmlns:common="clr-namespace:SparkyStudios.TrakLibrary.ViewModel.Common;assembly=SparkyStudios.TrakLibrary.ViewModel"
+    x:Name="FilterControlView">
+    <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+    </Grid.ColumnDefinitions>
+    <Label
+        Grid.Row="0"
+        Grid.Column="0"
+        Style="{StaticResource BaseBoldLabelStyle}"
+        Text="{Binding Header, Source={x:Reference FilterControlView}}">
+        <Label.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding GroupTappedCommand, Source={x:Reference FilterControlView}}" NumberOfTapsRequired="1" />
+        </Label.GestureRecognizers>
+    </Label>
+    <Image
+        Grid.Row="0"
+        Grid.Column="1"
+        Source="hamburger.png">
+        <Image.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding GroupTappedCommand, Source={x:Reference FilterControlView}}" NumberOfTapsRequired="1" />
+        </Image.GestureRecognizers>
+    </Image>
+
+    <!--  Filters  -->
+    <StackLayout
+        x:Name="SwitchControlLayout"
+        Grid.Row="1"
+        Grid.Column="0"
+        Grid.ColumnSpan="2"
+        BindableLayout.ItemsSource="{Binding ItemsSource, Source={x:Reference FilterControlView}}"
+        IsVisible="{Binding IsGroupExpanded, Source={x:Reference FilterControlView}}">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate>
+                <Grid Margin="0,5" x:DataType="common:ItemEntryViewModel">
+                    <Label Text="{Binding Name}" TextColor="{StaticResource TrakGrey}">
+                        <Label.Triggers>
+                            <DataTrigger
+                                Binding="{Binding Source={x:Reference FilterControlSwitch}, Path=IsToggled}"
+                                TargetType="Label"
+                                Value="True">
+                                <Setter Property="TextColor" Value="{StaticResource TrakWhite}" />
+                            </DataTrigger>
+                        </Label.Triggers>
+                        <Label.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ItemTappedCommand, Source={x:Reference FilterControlView}}" CommandParameter="{Binding}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+                    <Switch
+                        x:Name="FilterControlSwitch"
+                        HorizontalOptions="EndAndExpand"
+                        IsToggled="{Binding IsSelected, Mode=TwoWay}">
+                        <Switch.Behaviors>
+                            <behaviors:EventToCommandBehavior Command="{Binding ItemTappedCommand, Source={x:Reference FilterControlView}}" EventName="Toggled" />
+                        </Switch.Behaviors>
+                    </Switch>
+                </Grid>
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </StackLayout>
+    <BoxView
+        Grid.Row="2"
+        Grid.Column="0"
+        Grid.ColumnSpan="2"
+        HeightRequest="2"
+        HorizontalOptions="FillAndExpand"
+        WidthRequest="1"
+        Color="{StaticResource TrakPrimaryPurple}" />
+</Grid>

--- a/SparkyStudios.TrakLibrary/Controls/Common/FilterControl.xaml.cs
+++ b/SparkyStudios.TrakLibrary/Controls/Common/FilterControl.xaml.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+using SparkyStudios.TrakLibrary.ViewModel.Common;
+using Xamarin.Forms;
+
+namespace SparkyStudios.TrakLibrary.Controls.Common
+{
+    public partial class FilterControl
+    {
+        public static readonly BindableProperty HeaderProperty =
+            BindableProperty.Create(nameof(Header), typeof(string), typeof(FilterControl), string.Empty);
+        
+        public static readonly BindableProperty ItemsSourceProperty =
+            BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable<ItemEntryViewModel>), typeof(FilterControl));
+        
+        public static readonly BindableProperty GroupTappedCommandProperty =
+            BindableProperty.Create(nameof(GroupTappedCommand), typeof(ICommand), typeof(FilterControl));
+        
+        public static readonly BindableProperty ItemTappedCommandProperty =
+            BindableProperty.Create(nameof(ItemTappedCommand), typeof(ICommand), typeof(FilterControl));
+        
+        public static readonly BindableProperty IsGroupExpandedProperty =
+            BindableProperty.Create(nameof(IsGroupExpanded), typeof(bool), typeof(FilterControl));
+        
+        public FilterControl()
+        {
+            InitializeComponent();
+        }
+
+        public string Header
+        {
+            get => (string) GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+        
+        public IEnumerable<ItemEntryViewModel> ItemsSource
+        {
+            get => (IEnumerable<ItemEntryViewModel>)GetValue(ItemsSourceProperty);
+            set => SetValue(ItemsSourceProperty, value);
+        }
+
+        public ICommand GroupTappedCommand
+        {
+            get => (ICommand)GetValue(GroupTappedCommandProperty);
+            set => SetValue(GroupTappedCommandProperty, value);
+        }
+
+        public ICommand ItemTappedCommand
+        {
+            get => (ICommand) GetValue(ItemTappedCommandProperty);
+            set => SetValue(ItemTappedCommandProperty, value);
+        }
+        
+        public bool IsGroupExpanded
+        {
+            get => (bool) GetValue(IsGroupExpandedProperty);
+            set => SetValue(IsGroupExpandedProperty, value);
+        }
+    }
+}

--- a/SparkyStudios.TrakLibrary/Controls/Common/FullPageErrorControl.xaml
+++ b/SparkyStudios.TrakLibrary/Controls/Common/FullPageErrorControl.xaml
@@ -11,7 +11,10 @@
     <ContentView.Content>
         <!--  Full-page label telling the user that the request returned no results without error.  -->
         <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-            <Label Text="{Binding ErrorMessage, Source={x:Reference FullPageErrorControlView}}" />
+            <Label
+                HorizontalOptions="CenterAndExpand"
+                HorizontalTextAlignment="Center"
+                Text="{Binding ErrorMessage, Source={x:Reference FullPageErrorControlView}}" />
             <Image
                 HeightRequest="125"
                 IsVisible="{Binding IsRefreshable, Source={x:Reference FullPageErrorControlView}}"

--- a/SparkyStudios.TrakLibrary/Controls/Common/UserEntryItemTemplateControl.xaml
+++ b/SparkyStudios.TrakLibrary/Controls/Common/UserEntryItemTemplateControl.xaml
@@ -14,7 +14,7 @@
         <TapGestureRecognizer Command="{Binding TapCommand}" NumberOfTapsRequired="1" />
     </Grid.GestureRecognizers>
     <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="1*" />
+        <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="Auto" />
     </Grid.ColumnDefinitions>
 
@@ -25,7 +25,8 @@
         Grid.Column="0"
         Aspect="AspectFit"
         Source="{Binding ImageUrl}"
-        VerticalOptions="Start" />
+        VerticalOptions="Start"
+        WidthRequest="75" />
     <ActivityIndicator
         Grid.Row="0"
         Grid.Column="0"
@@ -36,7 +37,6 @@
     <Grid
         Grid.Row="0"
         Grid.Column="1"
-        Margin="5,0,0,0"
         RowSpacing="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -70,6 +70,8 @@
         <Label
             Grid.Row="2"
             FontSize="{StaticResource TrakFontSmall}"
+            LineBreakMode="TailTruncation"
+            MaxLines="1"
             Text="{Binding ItemSubTitle}" />
 
         <!--  The rating  -->

--- a/SparkyStudios.TrakLibrary/SparkyStudios.TrakLibrary.csproj
+++ b/SparkyStudios.TrakLibrary/SparkyStudios.TrakLibrary.csproj
@@ -33,6 +33,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Update="Views\Games\GameUserEntryFilterPage.xaml.cs">
+      <DependentUpon>GameUserEntryFilterPage.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Views\Login\LoginPage.xaml.cs">
       <DependentUpon>LoginPage.xaml</DependentUpon>
     </Compile>
@@ -42,7 +45,7 @@
     <Compile Update="Views\BaseMasterDetailContentPage.xaml.cs">
       <DependentUpon>BaseMasterDetailContentPage.xaml</DependentUpon>
     </Compile>
-    <Compile Update="Views\Games\GameUserEntryListPage.xaml.cs">
+    <Compile Update="Views\Games\GameUserEntryTabbedListPage.xaml.cs">
       <DependentUpon>GameUserEntryListPage.xaml</DependentUpon>
     </Compile>
     <Compile Update="Views\Games\GameUserEntriesTabbedPage.xaml.cs">
@@ -108,7 +111,7 @@
     <EmbeddedResource Update="Views\BaseMasterDetailContentPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Update="Views\Games\GameUserEntryListPage.xaml">
+    <EmbeddedResource Update="Views\Games\GameUserEntryTabbedListPage.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="Views\Games\GameUserEntriesTabbedPage.xaml">

--- a/SparkyStudios.TrakLibrary/Views/Games/GamePage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GamePage.xaml
@@ -150,6 +150,8 @@
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
                         Margin="20,0"
+                        FontSize="{StaticResource TrakFontSmall}"
+                        LineBreakMode="WordWrap"
                         Text="{Binding Publishers, Converter={StaticResource IEnumerableToStringConverter}}" />
 
                     <!--  The star rating for the current game. Only displayed if the game is in the users collection.  -->
@@ -162,7 +164,7 @@
                         <Label
                             FontSize="{StaticResource TrakFontSmall}"
                             IsVisible="False"
-                            Text="Not rated yet:"
+                            Text="{extensions:Translate GamePageNotRatedYet}"
                             TextColor="{StaticResource TrakGrey}"
                             VerticalTextAlignment="End">
                             <Label.Triggers>
@@ -303,8 +305,10 @@
                         Grid.Row="19"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
-                        Margin="20,15,20,10"
-                        FontSize="{StaticResource TrakFontLarge}"
+                        Margin="20,25,20,10"
+                        FontSize="{StaticResource TrakFontMedium}"
+                        LineBreakMode="WordWrap"
+                        MaxLines="2"
                         Style="{StaticResource TitleLabelStyle}"
                         Text="{extensions:Translate GamePageSimilarGames}" />
 

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntriesTabbedPage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntriesTabbedPage.xaml
@@ -11,19 +11,19 @@
     AutomationId="GameUserEntriesTabbedPage"
     BarBackgroundColor="{StaticResource TrakPrimaryBlue}">
     <TabbedPage.Children>
-        <games:GameUserEntryListPage
+        <games:GameUserEntryTabbedListPage
             Title="{extensions:Translate Backlog}"
             AutomationId="GameUserEntriesTabbedPageBacklogTab"
             BindingContext="{Binding BacklogViewModel}" />
-        <games:GameUserEntryListPage
+        <games:GameUserEntryTabbedListPage
             Title="{extensions:Translate Playing}"
             AutomationId="GameUserEntriesTabbedPagePlayingTab"
             BindingContext="{Binding InProgressViewModel}" />
-        <games:GameUserEntryListPage
+        <games:GameUserEntryTabbedListPage
             Title="{extensions:Translate Done}"
             AutomationId="GameUserEntriesTabbedPageDoneTab"
             BindingContext="{Binding CompletedViewModel}" />
-        <games:GameUserEntryListPage
+        <games:GameUserEntryTabbedListPage
             Title="{extensions:Translate Dropped}"
             AutomationId="GameUserEntriesTabbedPageDroppedTab"
             BindingContext="{Binding DroppedViewModel}" />

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryFilterPage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryFilterPage.xaml
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="SparkyStudios.TrakLibrary.Views.Games.GameUserEntryFilterPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:common="clr-namespace:SparkyStudios.TrakLibrary.Controls.Common;assembly=SparkyStudios.TrakLibrary"
+    xmlns:extensions="clr-namespace:SparkyStudios.TrakLibrary.Extensions;assembly=SparkyStudios.TrakLibrary"
+    xmlns:games="clr-namespace:SparkyStudios.TrakLibrary.ViewModel.Games;assembly=SparkyStudios.TrakLibrary.ViewModel">
+    <ContentPage.Content>
+        <Grid x:DataType="games:GameUserEntryFilterViewModel">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <!--  Full page control that is displayed when there's an error reported by the view model.  -->
+            <common:FullPageErrorControl
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                ErrorMessage="ERROR"
+                HorizontalOptions="Center"
+                IsRefreshable="True"
+                IsVisible="False"
+                RefreshCommand="{Binding LoadGameFiltersCommand}"
+                VerticalOptions="CenterAndExpand">
+                <common:FullPageErrorControl.Triggers>
+                    <MultiTrigger TargetType="common:FullPageErrorControl">
+                        <MultiTrigger.Conditions>
+                            <BindingCondition Binding="{Binding IsError}" Value="True" />
+                        </MultiTrigger.Conditions>
+                        <Setter Property="IsVisible" Value="True" />
+                    </MultiTrigger>
+                </common:FullPageErrorControl.Triggers>
+            </common:FullPageErrorControl>
+
+            <!--  Full page activity indicator that's shown when the game data is being loaded.  -->
+            <ActivityIndicator
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                HeightRequest="100"
+                HorizontalOptions="CenterAndExpand"
+                IsRunning="{Binding IsLoading}"
+                IsVisible="{Binding IsLoading}"
+                VerticalOptions="CenterAndExpand"
+                WidthRequest="100" />
+
+            <ScrollView
+                Grid.Row="0"
+                HorizontalOptions="FillAndExpand"
+                IsClippedToBounds="True"
+                IsVisible="False"
+                VerticalOptions="FillAndExpand">
+                <ScrollView.Triggers>
+                    <MultiTrigger TargetType="ScrollView">
+                        <MultiTrigger.Conditions>
+                            <BindingCondition Binding="{Binding HasLoaded}" Value="True" />
+                            <BindingCondition Binding="{Binding IsError}" Value="False" />
+                        </MultiTrigger.Conditions>
+                        <Setter Property="IsVisible" Value="True" />
+                    </MultiTrigger>
+                </ScrollView.Triggers>
+                <StackLayout Margin="20,0">
+                    <!--  Page title  -->
+                    <Label
+                        Margin="0,25,0,20"
+                        Style="{StaticResource TitleLabelStyle}"
+                        Text="{extensions:Translate GameUserEntryFilterPageTitle}" />
+
+                    <!--  Platform filters  -->
+                    <common:FilterControl
+                        GroupTappedCommand="{Binding PlatformGroupTappedCommand}"
+                        Header="{extensions:Translate GameUserEntryFilterPagePlatforms}"
+                        IsGroupExpanded="{Binding IsPlatformGroupExpanded}"
+                        ItemTappedCommand="{Binding PlatformTappedCommand}"
+                        ItemsSource="{Binding Platforms}" />
+
+                    <!--  Genre filters  -->
+                    <common:FilterControl
+                        Margin="0,15,0,0"
+                        GroupTappedCommand="{Binding GenreGroupTappedCommand}"
+                        Header="{extensions:Translate GameUserEntryFilterPageGenres}"
+                        IsGroupExpanded="{Binding IsGenreGroupExpanded}"
+                        ItemTappedCommand="{Binding GenreTappedCommand}"
+                        ItemsSource="{Binding Genres}" />
+
+                    <!--  Game mode filters  -->
+                    <common:FilterControl
+                        Margin="0,15,0,0"
+                        GroupTappedCommand="{Binding GameModeGroupTappedCommand}"
+                        Header="{extensions:Translate GameUserEntryFilterPageGameModes}"
+                        IsGroupExpanded="{Binding IsGameModeGroupExpanded}"
+                        ItemTappedCommand="{Binding GameModeTappedCommand}"
+                        ItemsSource="{Binding GameModes}" />
+
+                    <!--  Age rating filters  -->
+                    <common:FilterControl
+                        Margin="0,15,0,0"
+                        GroupTappedCommand="{Binding AgeRatingGroupTappedCommand}"
+                        Header="{extensions:Translate GameUserEntryFilterPageAgeRatings}"
+                        IsGroupExpanded="{Binding IsAgeRatingGroupExpanded}"
+                        ItemTappedCommand="{Binding AgeRatingTappedCommand}"
+                        ItemsSource="{Binding AgeRatings}" />
+
+                    <!--  Statuses filters  -->
+                    <common:FilterControl
+                        Margin="0,15,0,0"
+                        GroupTappedCommand="{Binding StatusGroupTappedCommand}"
+                        Header="{extensions:Translate GameUserEntryFilterPageStatuses}"
+                        IsGroupExpanded="{Binding IsStatusGroupExpanded}"
+                        ItemTappedCommand="{Binding StatusTappedCommand}"
+                        ItemsSource="{Binding Statuses}" />
+                </StackLayout>
+            </ScrollView>
+            <Button
+                Grid.Row="1"
+                Margin="20"
+                Command="{Binding ApplyCommand}"
+                IsVisible="False"
+                Style="{StaticResource PrimaryButtonStyle}"
+                Text="{extensions:Translate GameUserEntryFilterPageApply}">
+                <Button.Triggers>
+                    <MultiTrigger TargetType="Button">
+                        <MultiTrigger.Conditions>
+                            <BindingCondition Binding="{Binding HasLoaded}" Value="True" />
+                            <BindingCondition Binding="{Binding IsError}" Value="False" />
+                        </MultiTrigger.Conditions>
+                        <Setter Property="IsVisible" Value="True" />
+                    </MultiTrigger>
+                </Button.Triggers>
+            </Button>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryFilterPage.xaml.cs
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryFilterPage.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+
+namespace SparkyStudios.TrakLibrary.Views.Games
+{
+    public partial class GameUserEntryFilterPage
+    {
+        public GameUserEntryFilterPage()
+        {
+            InitializeComponent();
+            BackgroundImageSource = ImageSource.FromFile("background.png");
+        }
+    }
+}

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryListPage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryListPage.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
+
 <ContentPage
     x:Class="SparkyStudios.TrakLibrary.Views.Games.GameUserEntryListPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
@@ -7,6 +8,7 @@
     xmlns:extensions="clr-namespace:SparkyStudios.TrakLibrary.Extensions;assembly=SparkyStudios.TrakLibrary"
     xmlns:games="clr-namespace:SparkyStudios.TrakLibrary.ViewModel.Games;assembly=SparkyStudios.TrakLibrary.ViewModel"
     x:Name="GameUserEntryList"
+    Title="{extensions:Translate GameUserEntryListPageTitle}"
     BackgroundColor="{StaticResource TrakPrimaryBlue}">
     <ContentPage.Content>
         <StackLayout x:DataType="games:GameUserEntryListViewModel">
@@ -21,22 +23,6 @@
                     RemainingItemsThreshold="0"
                     RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}"
                     VerticalOptions="StartAndExpand">
-                    <CollectionView.Header>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="2*" />
-                            </Grid.ColumnDefinitions>
-                            <Button
-                                Grid.Column="0"
-                                Margin="20,20,0,0"
-                                FontFamily="Mulish-Regular"
-                                FontSize="{StaticResource TrakFontMedium}"
-                                HorizontalOptions="Start"
-                                Style="{StaticResource SecondaryButtonStyle}"
-                                Text="Filter" />
-                        </Grid>
-                    </CollectionView.Header>
                     <CollectionView.EmptyView>
                         <StackLayout>
                             <!--  Full-page label telling the user that the request returned no results without error.  -->
@@ -45,6 +31,7 @@
                                 HorizontalOptions="Center"
                                 HorizontalTextAlignment="Center"
                                 IsVisible="False"
+                                Text="{extensions:Translate GameUserEntryListPageEmptyResults}"
                                 VerticalOptions="CenterAndExpand"
                                 VerticalTextAlignment="Center">
                                 <Label.Triggers>
@@ -52,25 +39,16 @@
                                         <MultiTrigger.Conditions>
                                             <BindingCondition Binding="{Binding IsEmpty}" Value="True" />
                                             <BindingCondition Binding="{Binding IsError}" Value="False" />
+                                            <BindingCondition Binding="{Binding HasLoaded}" Value="True" />
                                         </MultiTrigger.Conditions>
                                         <Setter Property="IsVisible" Value="True" />
                                     </MultiTrigger>
                                 </Label.Triggers>
-                                <Label.FormattedText>
-                                    <FormattedString>
-                                        <Span Text="{extensions:Translate GameUserEntryListPageEmpty}" />
-                                        <Span Text="&quot;" />
-                                        <Span
-                                            FontAttributes="Bold"
-                                            FontSize="Medium"
-                                            Text="{Binding Source={x:Reference GameUserEntryList}, Path=Title}" />
-                                        <Span Text="&quot;" />
-                                    </FormattedString>
-                                </Label.FormattedText>
                             </Label>
                             <!--  Full page control that is displayed when the page results are empty and an error was returned.  -->
                             <common:FullPageErrorControl
-                                ErrorMessage="{extensions:Translate GameUserEntryListPageEmptyServerError}"
+                                Margin="20"
+                                ErrorMessage="{Binding ErrorMessage}"
                                 HorizontalOptions="Center"
                                 IsRefreshable="True"
                                 IsVisible="False"
@@ -79,7 +57,6 @@
                                 <common:FullPageErrorControl.Triggers>
                                     <MultiTrigger TargetType="common:FullPageErrorControl">
                                         <MultiTrigger.Conditions>
-                                            <BindingCondition Binding="{Binding IsEmpty}" Value="True" />
                                             <BindingCondition Binding="{Binding IsError}" Value="True" />
                                         </MultiTrigger.Conditions>
                                         <Setter Property="IsVisible" Value="True" />
@@ -91,7 +68,7 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <Grid>
-                                <common:UserEntryItemTemplateControl Margin="0,10,20,10" />
+                                <common:UserEntryItemTemplateControl Margin="20,10" />
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
@@ -99,21 +76,19 @@
             </RefreshView>
 
             <ActivityIndicator
-                Margin="0,15,0,0"
+                HeightRequest="100"
                 HorizontalOptions="CenterAndExpand"
-                IsEnabled="{Binding IsLoading}"
                 IsRunning="{Binding IsLoading}"
                 IsVisible="{Binding IsLoading}"
-                MinimumHeightRequest="100"
-                MinimumWidthRequest="100"
-                VerticalOptions="CenterAndExpand" />
+                VerticalOptions="CenterAndExpand"
+                WidthRequest="100" />
 
             <Button
                 Margin="20"
                 Command="{Binding AddGameCommand}"
                 IsVisible="{Binding IsError, Converter={StaticResource NegateBooleanConverter}}"
                 Style="{StaticResource PrimaryButtonStyle}"
-                Text="Add game" />
+                Text="{extensions:Translate GameUserEntryListPageAddGame}" />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryTabbedListPage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryTabbedListPage.xaml
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="SparkyStudios.TrakLibrary.Views.Games.GameUserEntryTabbedListPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:common="clr-namespace:SparkyStudios.TrakLibrary.Controls.Common;assembly=SparkyStudios.TrakLibrary"
+    xmlns:extensions="clr-namespace:SparkyStudios.TrakLibrary.Extensions;assembly=SparkyStudios.TrakLibrary"
+    xmlns:games="clr-namespace:SparkyStudios.TrakLibrary.ViewModel.Games;assembly=SparkyStudios.TrakLibrary.ViewModel"
+    x:Name="GameUserEntryList"
+    BackgroundColor="{StaticResource TrakPrimaryBlue}">
+    <ContentPage.Content>
+        <StackLayout x:DataType="games:GameUserEntryTabbedListViewModel">
+            <RefreshView
+                Command="{Binding LoadCommand}"
+                IsEnabled="{Binding IsLoading, Converter={StaticResource NegateBooleanConverter}}"
+                IsRefreshing="{Binding IsRefreshing}"
+                IsVisible="{Binding IsLoading, Converter={StaticResource NegateBooleanConverter}}">
+                <CollectionView
+                    HorizontalOptions="StartAndExpand"
+                    ItemsSource="{Binding Items}"
+                    RemainingItemsThreshold="0"
+                    RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}"
+                    VerticalOptions="StartAndExpand">
+                    <CollectionView.Header>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="2*" />
+                            </Grid.ColumnDefinitions>
+                            <Button
+                                Grid.Column="0"
+                                Margin="20,20,0,0"
+                                Command="{Binding FilterCommand}"
+                                FontFamily="Mulish-Regular"
+                                FontSize="{StaticResource TrakFontMedium}"
+                                HorizontalOptions="Start"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Text="Filter" />
+                        </Grid>
+                    </CollectionView.Header>
+                    <CollectionView.EmptyView>
+                        <StackLayout>
+                            <!--  Full-page label telling the user that the request returned no results without error.  -->
+                            <Label
+                                Margin="20,0"
+                                HorizontalOptions="Center"
+                                HorizontalTextAlignment="Center"
+                                IsVisible="False"
+                                VerticalOptions="CenterAndExpand"
+                                VerticalTextAlignment="Center">
+                                <Label.Triggers>
+                                    <MultiTrigger TargetType="Label">
+                                        <MultiTrigger.Conditions>
+                                            <BindingCondition Binding="{Binding IsEmpty}" Value="True" />
+                                            <BindingCondition Binding="{Binding IsError}" Value="False" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter Property="IsVisible" Value="True" />
+                                    </MultiTrigger>
+                                </Label.Triggers>
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="{extensions:Translate GameUserEntryListPageEmpty}" />
+                                        <Span Text="&quot;" />
+                                        <Span
+                                            FontAttributes="Bold"
+                                            FontSize="Medium"
+                                            Text="{Binding Source={x:Reference GameUserEntryList}, Path=Title}" />
+                                        <Span Text="&quot;" />
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <!--  Full page control that is displayed when the page results are empty and an error was returned.  -->
+                            <common:FullPageErrorControl
+                                ErrorMessage="{extensions:Translate GameUserEntryListPageEmptyServerError}"
+                                HorizontalOptions="Center"
+                                IsRefreshable="True"
+                                IsVisible="False"
+                                RefreshCommand="{Binding LoadCommand}"
+                                VerticalOptions="CenterAndExpand">
+                                <common:FullPageErrorControl.Triggers>
+                                    <MultiTrigger TargetType="common:FullPageErrorControl">
+                                        <MultiTrigger.Conditions>
+                                            <BindingCondition Binding="{Binding IsEmpty}" Value="True" />
+                                            <BindingCondition Binding="{Binding IsError}" Value="True" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter Property="IsVisible" Value="True" />
+                                    </MultiTrigger>
+                                </common:FullPageErrorControl.Triggers>
+                            </common:FullPageErrorControl>
+                        </StackLayout>
+                    </CollectionView.EmptyView>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <common:UserEntryItemTemplateControl Margin="20,10" />
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </RefreshView>
+
+            <ActivityIndicator
+                HorizontalOptions="CenterAndExpand"
+                IsRunning="{Binding IsLoading}"
+                IsVisible="{Binding IsLoading}"
+                MinimumHeightRequest="100"
+                MinimumWidthRequest="100"
+                VerticalOptions="CenterAndExpand" />
+
+            <Button
+                Margin="20"
+                Command="{Binding AddGameCommand}"
+                IsVisible="{Binding IsError, Converter={StaticResource NegateBooleanConverter}}"
+                Style="{StaticResource PrimaryButtonStyle}"
+                Text="{extensions:Translate GameUserEntryListPageAddGame}" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryTabbedListPage.xaml.cs
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameUserEntryTabbedListPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace SparkyStudios.TrakLibrary.Views.Games
+{
+    public partial class GameUserEntryTabbedListPage
+    {
+        public GameUserEntryTabbedListPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
- Ensured the properties being read in and retrieved know that the data being returned by the API is now in the snake case format.
- Centre the error message test on the FullPageErrorControl.
- Moved the HasLoaded boolean property to the parent ReactiveViewModel.
- Fixed some un-translated text on the views. 
- Changed the GameUserEntryListPage to the GameUserEntryTabbedListPage, as it only contains information that is unique to being within a tab.
- Added a new page, GameUserEntryListPage, which is similar to the new tabbed page but doesn't include tab information or a button to filter results.
- Added a filter button to the tabbed game user entry page.
- Added a new page which will display all of the filter information. 
- Added a new page which will display the results of the game user entry filter.
- Added parameter checking for the url passed into the RestServiceHttpClientImpl, which will throw exceptions if the URL is null or empty.
- Changed the size of the image for games to ensure it doesn't take up too much room.
- Change unit tests.

Two caveats with this issue: 
- The images for the filter is still incorrect until they can be exported from the design. However, some research needs to be done into a library that may make asset management a lot easier.
- There are no unit tests currently for the new view models, they'll come later. 