### PR TITLE
APP-33: Support different images for different components.

### DIFF
--- a/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameViewModelTest.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel.Test/Games/GameViewModelTest.cs
@@ -190,7 +190,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
                 Links = new Dictionary<string, HateoasLink>
                 {
                     {
-                        "image", new HateoasLink
+                        "medium_image", new HateoasLink
                         {
                             Href = new Uri("https://traklibrary.com/image")
                         }
@@ -241,7 +241,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
             _scheduler.Start();
 
             // Assert
-            Assert.AreEqual(gameDetails.GetLink("image").OriginalString, _gameViewModel.ImageUrl.OriginalString,
+            Assert.AreEqual(gameDetails.GetLink("medium_image").OriginalString, _gameViewModel.ImageUrl.OriginalString,
                 "The image url should match.");
             Assert.AreEqual(gameDetails.Title, _gameViewModel.GameTitle, "The titles should match.");
             Assert.AreEqual(gameDetails.Description, _gameViewModel.Description, "The titles should match.");
@@ -322,7 +322,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
                 Links = new Dictionary<string, HateoasLink>
                 {
                     {
-                        "image", new HateoasLink
+                        "medium_image", new HateoasLink
                         {
                             Href = new Uri("https://traklibrary.com/image")
                         }
@@ -387,7 +387,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Test.Games
             _scheduler.Start();
 
             // Assert
-            Assert.AreEqual(gameDetails.GetLink("image").OriginalString, _gameViewModel.ImageUrl.OriginalString,
+            Assert.AreEqual(gameDetails.GetLink("medium_image").OriginalString, _gameViewModel.ImageUrl.OriginalString,
                 "The image url should match.");
             Assert.AreEqual(gameDetails.Title, _gameViewModel.GameTitle, "The titles should match.");
             Assert.AreEqual(gameDetails.Description, _gameViewModel.Description, "The titles should match.");

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameLibraryListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameLibraryListViewModel.cs
@@ -256,7 +256,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
 
             return new ListItemViewModel
             {
-                ImageUrl = gameDetails.GetLink("image"),
+                ImageUrl = gameDetails.GetLink("small_image"),
                 HeaderDetails = platforms,
                 ItemTitle = gameDetails.Title,
                 ItemSubTitle = string.Join(", ", gameDetails.Publishers.Select(x => x.Name)),

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryListViewModel.cs
@@ -196,7 +196,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         {
             return new ListItemViewModel
             {
-                ImageUrl = gameUserEntry.GetLink("image"),
+                ImageUrl = gameUserEntry.GetLink("small_image"),
                 HeaderDetails = gameUserEntry.GameUserEntryPlatforms?.Select(x => new ItemEntryViewModel
                 {
                     Name = x.PlatformName,

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryTabbedListViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameUserEntryTabbedListViewModel.cs
@@ -255,7 +255,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
         {
             return new ListItemViewModel
             {
-                ImageUrl = gameUserEntry.GetLink("image"),
+                ImageUrl = gameUserEntry.GetLink("small_image"),
                 HeaderDetails = gameUserEntry.GameUserEntryPlatforms?.Select(x => new ItemEntryViewModel
                 {
                     Name = x.PlatformName,

--- a/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
+++ b/SparkyStudios.TrakLibrary.ViewModel/Games/GameViewModel.cs
@@ -274,7 +274,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
             // Retrieve the game and set some game information on the view.
             var gameDetails = await _restService.GetAsync<GameDetails>(GameUrl.OriginalString);
             _gameId = gameDetails.Id;
-            ImageUrl = gameDetails.GetLink("image");
+            ImageUrl = gameDetails.GetLink("medium_image");
             GameTitle = gameDetails.Title;
             Description = gameDetails.Description;
             Publishers = gameDetails.Publishers;
@@ -361,7 +361,7 @@ namespace SparkyStudios.TrakLibrary.ViewModel.Games
             foreach (var game in games)
                 similarGames.Add(new ListItemViewModel
                 {
-                    ImageUrl = game.GetLink("image"),
+                    ImageUrl = game.GetLink("small_image"),
                     HeaderDetails = game.Platforms.Select(x => new ItemEntryViewModel
                     {
                         Name = x.Name,

--- a/SparkyStudios.TrakLibrary/Controls/Common/DividerControl.xaml
+++ b/SparkyStudios.TrakLibrary/Controls/Common/DividerControl.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:common="clr-namespace:SparkyStudios.TrakLibrary.ViewModel.Common;assembly=SparkyStudios.TrakLibrary.ViewModel"
     x:Name="DividerControlView"
-    BindableLayout.ItemsSource="{Binding ItemsSource, Source={x:Reference DividerControlView}}"
+    BindableLayout.ItemsSource="{Binding LimitedItemsSource, Source={x:Reference DividerControlView}}"
     Orientation="Horizontal">
     <BindableLayout.ItemTemplate>
         <DataTemplate>

--- a/SparkyStudios.TrakLibrary/Controls/Common/DividerControl.xaml.cs
+++ b/SparkyStudios.TrakLibrary/Controls/Common/DividerControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using SparkyStudios.TrakLibrary.ViewModel.Common;
 using Xamarin.Forms;
 
@@ -12,9 +13,14 @@ namespace SparkyStudios.TrakLibrary.Controls.Common
         public static readonly BindableProperty FontSizeProperty =
             BindableProperty.Create(nameof(Divider), typeof(double), typeof(DividerControl), 14.0D);
         
-        public static readonly BindableProperty ItemsSourceProperty =
-            BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable<ItemEntryViewModel>), typeof(DividerControl));
+        public static readonly BindableProperty LimitProperty =
+            BindableProperty.Create(nameof(Limit), typeof(int), typeof(DividerControl), int.MaxValue);
         
+        public static readonly BindableProperty ItemsSourceProperty =
+            BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable<ItemEntryViewModel>), typeof(DividerControl), propertyChanged: OnItemsSourceChanged);
+
+        private IEnumerable<ItemEntryViewModel> _limitedItemsSource;
+
         public DividerControl()
         {
             InitializeComponent();
@@ -31,11 +37,48 @@ namespace SparkyStudios.TrakLibrary.Controls.Common
             get => (double) GetValue(FontSizeProperty);
             set => SetValue(FontSizeProperty, value);
         }
+
+        public int Limit
+        {
+            get => (int) GetValue(LimitProperty);
+            set => SetValue(LimitProperty, value);
+        }
+
+        private static void OnItemsSourceChanged(BindableObject bindableObject, object oldValue, object newValue)
+        {
+            var dividerControl = (DividerControl) bindableObject;
+            var limit = dividerControl.Limit;
+
+            IList<ItemEntryViewModel> items = ((IEnumerable<ItemEntryViewModel>) newValue)
+                ?.Take(limit)
+                .ToList();
+
+            var allItems = (IEnumerable<ItemEntryViewModel>) newValue;
+            if (allItems != null && allItems.Count() > limit)
+            {
+                items.Add(new ItemEntryViewModel
+                {
+                    Name = "..."
+                });
+            }
+
+            dividerControl.LimitedItemsSource = items;
+        }
         
         public IEnumerable<ItemEntryViewModel> ItemsSource
         {
             get => (IEnumerable<ItemEntryViewModel>)GetValue(ItemsSourceProperty);
             set => SetValue(ItemsSourceProperty, value);
+        }
+
+        public IEnumerable<ItemEntryViewModel> LimitedItemsSource
+        {
+            get => _limitedItemsSource;
+            set
+            {
+                _limitedItemsSource = value;
+                OnPropertyChanged(nameof(LimitedItemsSource));
+            }
         }
     }
 }

--- a/SparkyStudios.TrakLibrary/Controls/Common/UserEntryItemTemplateControl.xaml
+++ b/SparkyStudios.TrakLibrary/Controls/Common/UserEntryItemTemplateControl.xaml
@@ -51,7 +51,8 @@
             Divider="|"
             FontSize="{StaticResource TrakFontSmall}"
             HeightRequest="18"
-            ItemsSource="{Binding HeaderDetails}" />
+            ItemsSource="{Binding HeaderDetails}"
+            Limit="3" />
 
         <!--  The user entry item title  -->
         <Label

--- a/SparkyStudios.TrakLibrary/Views/Games/GameOptionsPage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GameOptionsPage.xaml
@@ -150,7 +150,7 @@
                                     <Label
                                         Grid.Column="0"
                                         LineBreakMode="WordWrap"
-                                        MaxLines="2"
+                                        MaxLines="3"
                                         Text="{Binding Name}"
                                         TextColor="{StaticResource TrakGrey}"
                                         VerticalOptions="StartAndExpand">

--- a/SparkyStudios.TrakLibrary/Views/Games/GamePage.xaml
+++ b/SparkyStudios.TrakLibrary/Views/Games/GamePage.xaml
@@ -126,7 +126,8 @@
                         Divider="|"
                         FontSize="{StaticResource TrakFontMedium}"
                         HeightRequest="25"
-                        ItemsSource="{Binding Platforms}" />
+                        ItemsSource="{Binding Platforms}"
+                        Limit="3" />
 
                     <!--  Game title  -->
                     <Label


### PR DESCRIPTION
- Added support for using multiple images. Small images are used in lists, medium are used in the GamePage.
- Changed DividerControl to not cause elements to run off the page by limiting them to 3, with ellipsis to indicate more are available.